### PR TITLE
[libshortfin] Implement multi-device CPU system config.

### DIFF
--- a/libshortfin/python/lib_ext.cc
+++ b/libshortfin/python/lib_ext.cc
@@ -43,8 +43,10 @@ or integer values:
     eligible physical cores on the node.
 
 Args:
-  env_prefix: If specified, then any options not found in kwargs will be looked
-    for in the environment by prefixing the upper-cased key with this value.
+  env_prefix: Controls how options are looked up in the environment. By default,
+    the prefix is "SHORTFIN_" and upper-cased options are appended to it. Any
+    option not explicitly specified but in the environment will be used. Pass
+    None to disable environment lookup.
   **kwargs: Key/value arguments for controlling setup of the system.
 )";
 
@@ -1068,8 +1070,8 @@ void BindHostSystem(py::module_ &global_m) {
             new (self) local::systems::HostCPUSystemBuilder(
                 iree_allocator_system(), std::move(options));
           },
-          py::kw_only(), py::arg("env_prefix") = py::none(), py::arg("kwargs"),
-          DOCSTRING_HOSTCPU_SYSTEM_BUILDER_CTOR);
+          py::kw_only(), py::arg("env_prefix").none() = "SHORTFIN_",
+          py::arg("kwargs"), DOCSTRING_HOSTCPU_SYSTEM_BUILDER_CTOR);
   py::class_<local::systems::HostCPUDevice, local::Device>(m, "HostCPUDevice");
 }
 

--- a/libshortfin/python/lib_ext.cc
+++ b/libshortfin/python/lib_ext.cc
@@ -432,7 +432,12 @@ void BindLocal(py::module_ &m) {
                 py::cast(system_ptr, py::rv_policy::take_ownership);
             live_system_refs.attr("add")(system_obj);
             if (check_options) {
-              self.config_options().CheckAllOptionsConsumed();
+              try {
+                self.config_options().CheckAllOptionsConsumed();
+              } catch (...) {
+                system_obj.attr("shutdown")();
+                throw;
+              }
             }
             return system_obj;
           },

--- a/libshortfin/src/shortfin/local/device.cc
+++ b/libshortfin/src/shortfin/local/device.cc
@@ -59,7 +59,9 @@ Device::Device(DeviceAddress address, iree::hal_device_ptr hal_device,
     : address_(std::move(address)),
       hal_device_(std::move(hal_device)),
       node_affinity_(node_affinity),
-      capabilities_(capabilities) {}
+      capabilities_(capabilities) {
+  assert(hal_device_ && "nullptr iree_hal_device_t");
+}
 
 Device::~Device() = default;
 

--- a/libshortfin/src/shortfin/local/device.cc
+++ b/libshortfin/src/shortfin/local/device.cc
@@ -55,19 +55,19 @@ std::string DeviceAffinity::to_s() const {
 // -------------------------------------------------------------------------- //
 
 Device::Device(DeviceAddress address, iree::hal_device_ptr hal_device,
-               int node_affinity, bool node_locked)
+               int node_affinity, uint32_t capabilities)
     : address_(std::move(address)),
       hal_device_(std::move(hal_device)),
       node_affinity_(node_affinity),
-      node_locked_(node_locked) {}
+      capabilities_(capabilities) {}
 
 Device::~Device() = default;
 
 std::string Device::to_s() const {
   return fmt::format(
-      "Device(name='{}', ordinal={}:{}, node_affinity={}, node_locked={})",
+      "Device(name='{}', ordinal={}:{}, node_affinity={}, capabilities=0x{:x})",
       name(), address().instance_ordinal, address().queue_ordinal,
-      node_affinity(), node_locked());
+      node_affinity(), capabilities_);
 }
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/device.h
+++ b/libshortfin/src/shortfin/local/device.h
@@ -123,14 +123,22 @@ struct SHORTFIN_API DeviceAddress {
 // A device attached to the LocalSystem.
 class SHORTFIN_API Device {
  public:
+  enum class Capabilities : uint32_t {
+    NONE = 0,
+    // Indicates that the device has unified memory with the host that should
+    // be preferred when performing device-visible buffer manipulation. Note
+    // that many devices technically support host unified memory, but this bit
+    // indicates that it should be used for loading/storing/accessing device
+    // buffers without managing a separate staging DMA buffer.
+    PREFER_HOST_UNIFIED_MEMORY = 1,
+  };
   Device(DeviceAddress address, iree::hal_device_ptr hal_device,
-         int node_affinity, bool node_locked);
+         int node_affinity, uint32_t capabilities);
   virtual ~Device();
 
   const DeviceAddress &address() const { return address_; }
   std::string_view name() const { return address_.device_name; }
   int node_affinity() const { return node_affinity_; }
-  bool node_locked() const { return node_locked_; }
   iree_hal_device_t *hal_device() const { return hal_device_.get(); }
 
   std::string to_s() const;
@@ -144,7 +152,7 @@ class SHORTFIN_API Device {
   DeviceAddress address_;
   iree::hal_device_ptr hal_device_;
   int node_affinity_;
-  bool node_locked_;
+  uint32_t capabilities_ = 0;
 };
 
 // Holds a reference to a Device* and a bitmask of queues that are being

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -19,6 +19,7 @@
 #include "shortfin/local/worker.h"
 #include "shortfin/support/api.h"
 #include "shortfin/support/blocking_executor.h"
+#include "shortfin/support/config.h"
 #include "shortfin/support/iree_concurrency.h"
 #include "shortfin/support/iree_helpers.h"
 #include "shortfin/support/stl_extras.h"
@@ -220,18 +221,22 @@ using SystemPtr = std::shared_ptr<System>;
 // Base class for configuration objects for setting up a System.
 class SHORTFIN_API SystemBuilder {
  public:
-  SystemBuilder(iree_allocator_t host_allocator)
-      : host_allocator_(host_allocator) {}
+  SystemBuilder(iree_allocator_t host_allocator,
+                ConfigOptions config_options = {})
+      : host_allocator_(host_allocator),
+        config_options_(std::move(config_options)) {}
   SystemBuilder() : SystemBuilder(iree_allocator_system()) {}
   virtual ~SystemBuilder() = default;
 
   iree_allocator_t host_allocator() { return host_allocator_; }
+  const ConfigOptions &config_options() const { return config_options_; }
 
   // Construct a System
   virtual SystemPtr CreateSystem() = 0;
 
  private:
   const iree_allocator_t host_allocator_;
+  ConfigOptions config_options_;
 };
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/libshortfin/src/shortfin/local/systems/amdgpu.cc
@@ -101,7 +101,7 @@ SystemPtr AMDGPUSystemBuilder::CreateSystem() {
             /*queue_ordinal=*/0,
             /*instance_topology_address=*/{0}),
         std::move(device), /*node_affinity=*/0,
-        /*node_locked=*/false));
+        /*capabilities=*/static_cast<uint32_t>(Device::Capabilities::NONE)));
   }
 
   // Initialize CPU devices if requested.

--- a/libshortfin/src/shortfin/local/systems/host.cc
+++ b/libshortfin/src/shortfin/local/systems/host.cc
@@ -209,7 +209,7 @@ void HostCPUSystemBuilder::InitializeHostCPUDevices(System &lsys,
             /*instance_ordinal=*/0,
             /*queue_ordinal=*/queue_index,
             /*instance_topology_address=*/{queue_index}),
-        /*hal_device=*/std::move(device),
+        /*hal_device=*/device,
         /*node_affinity=*/node_id,
         /*capabilities=*/
         static_cast<int32_t>(

--- a/libshortfin/src/shortfin/local/systems/host.cc
+++ b/libshortfin/src/shortfin/local/systems/host.cc
@@ -6,6 +6,8 @@
 
 #include "shortfin/local/systems/host.h"
 
+#include <bit>
+
 #include "iree/hal/local/loaders/registration/init.h"
 #include "shortfin/support/iree_helpers.h"
 #include "shortfin/support/logging.h"
@@ -13,9 +15,17 @@
 namespace shortfin::local::systems {
 
 namespace {
-const std::string_view SYSTEM_DEVICE_CLASS = "host-cpu";
+const std::string_view SYSTEM_DEVICE_CLASS = "hostcpu";
 const std::string_view LOGICAL_DEVICE_CLASS = "cpu";
 const std::string_view HAL_DRIVER_PREFIX = "local";
+
+struct TopologyHolder {
+  TopologyHolder() { iree_task_topology_initialize(&topology); }
+  ~TopologyHolder() { iree_task_topology_deinitialize(&topology); }
+
+  iree_task_topology_t topology;
+};
+
 }  // namespace
 
 // -------------------------------------------------------------------------- //
@@ -25,7 +35,6 @@ const std::string_view HAL_DRIVER_PREFIX = "local";
 HostCPUSystemBuilder::Deps::Deps(iree_allocator_t host_allocator) {
   iree_task_executor_options_initialize(&task_executor_options);
   iree_hal_task_device_params_initialize(&task_params);
-  iree_task_topology_initialize(&task_topology_options);
 
 #ifndef NDEBUG
   // TODO: In normal IREE programs, this is exposed as --task_abort_on_failure.
@@ -39,23 +48,21 @@ HostCPUSystemBuilder::Deps::Deps(iree_allocator_t host_allocator) {
 }
 
 HostCPUSystemBuilder::Deps::~Deps() {
-  iree_task_topology_deinitialize(&task_topology_options);
   for (iree_host_size_t i = 0; i < loader_count; ++i) {
     iree_hal_executable_loader_release(loaders[i]);
   }
   if (device_allocator) {
     iree_hal_allocator_release(device_allocator);
   }
-  if (executor) {
-    iree_task_executor_release(executor);
-  }
   if (plugin_manager) {
     iree_hal_executable_plugin_manager_release(plugin_manager);
   }
 }
 
-HostCPUSystemBuilder::HostCPUSystemBuilder(iree_allocator_t host_allocator)
-    : HostSystemBuilder(host_allocator), host_cpu_deps_(host_allocator) {}
+HostCPUSystemBuilder::HostCPUSystemBuilder(iree_allocator_t host_allocator,
+                                           ConfigOptions config_options)
+    : HostSystemBuilder(host_allocator, std::move(config_options)),
+      host_cpu_deps_(host_allocator) {}
 
 HostCPUSystemBuilder::~HostCPUSystemBuilder() = default;
 
@@ -74,6 +81,44 @@ void HostCPUSystemBuilder::InitializeHostCPUDefaults() {
         &host_cpu_deps_.loader_count, host_cpu_deps_.loaders,
         host_allocator()));
   }
+
+  // Queue executors.
+}
+
+std::vector<iree_host_size_t>
+HostCPUSystemBuilder::SelectHostCPUNodesFromOptions() {
+  const unsigned MAX_NODE_COUNT = 64u;
+  const iree_host_size_t available_node_count = std::max(
+      1u, std::min(MAX_NODE_COUNT, static_cast<unsigned>(
+                                       iree_task_topology_query_node_count())));
+  auto topology_nodes = config_options().GetOption("hostcpu_topology_nodes");
+
+  std::vector<iree_host_size_t> nodes;
+  if (!topology_nodes || topology_nodes->empty() ||
+      *topology_nodes == "current") {
+    // If topology_nodes not specified or "current", use a single default node.
+    nodes.push_back(iree_task_topology_query_current_node());
+  } else if (*topology_nodes == "all") {
+    // If topology_nodes == "all", create a mask of all available nodes.
+    nodes.reserve(available_node_count);
+    for (auto i = 0; i < available_node_count; ++i) {
+      nodes.push_back(i);
+    }
+  } else {
+    // Otherwise, parse it as an integer list.
+    auto topology_node_ids =
+        config_options().GetIntList("hostcpu_topology_nodes");
+    assert(topology_node_ids);
+    for (int64_t node_id : *topology_node_ids) {
+      if (node_id < 0 || node_id >= available_node_count) {
+        throw std::invalid_argument(fmt::format(
+            "Illegal value {} in hostcpu_topology_nodes: Expected [0..{}]",
+            node_id, available_node_count - 1));
+      }
+      nodes.push_back(node_id);
+    }
+  }
+  return nodes;
 }
 
 SystemPtr HostCPUSystemBuilder::CreateSystem() {
@@ -92,14 +137,34 @@ iree_hal_driver_t *HostCPUSystemBuilder::InitializeHostCPUDriver(System &lsys) {
   // object.
   SHORTFIN_THROW_IF_ERROR(iree_task_executor_options_initialize_from_flags(
       &host_cpu_deps_.task_executor_options));
-  // TODO: Do something smarter than pinning to NUMA node 0.
-  SHORTFIN_THROW_IF_ERROR(iree_task_topology_initialize_from_flags(
-      /*node_id=*/0, &host_cpu_deps_.task_topology_options));
 
-  SHORTFIN_THROW_IF_ERROR(
-      iree_task_executor_create(host_cpu_deps_.task_executor_options,
-                                &host_cpu_deps_.task_topology_options,
-                                host_allocator(), &host_cpu_deps_.executor));
+  // Determine NUMA nodes to use.
+  auto selected_nodes = SelectHostCPUNodesFromOptions();
+  auto max_group_count = config_options().GetInt(
+      "hostcpu_topology_max_group_count", /*non_negative=*/true);
+  if (!max_group_count) {
+    max_group_count = 64;
+  }
+
+  // Create one queue executor per node.
+  std::vector<iree::task_executor_ptr> queue_executors;
+  queue_executors.reserve(selected_nodes.size());
+  queue_node_ids_.reserve(selected_nodes.size());
+  for (auto node_id : selected_nodes) {
+    TopologyHolder topology;
+    iree_task_topology_performance_level_t performance_level =
+        IREE_TASK_TOPOLOGY_PERFORMANCE_LEVEL_ANY;
+    SHORTFIN_THROW_IF_ERROR(iree_task_topology_initialize_from_physical_cores(
+        node_id, performance_level, *max_group_count, &topology.topology));
+    logging::debug("Creating hostcpu queue for NUMA node {} with {} groups",
+                   node_id, iree_task_topology_group_count(&topology.topology));
+    queue_executors.push_back({});
+    auto &executor = queue_executors.back();
+    SHORTFIN_THROW_IF_ERROR(iree_task_executor_create(
+        host_cpu_deps_.task_executor_options, &topology.topology,
+        host_allocator(), executor.for_output()));
+    queue_node_ids_.push_back(node_id);
+  }
 
   // Create the driver and save it in the System.
   iree::hal_driver_ptr driver;
@@ -110,7 +175,8 @@ iree_hal_driver_t *HostCPUSystemBuilder::InitializeHostCPUDriver(System &lsys) {
           .data = HAL_DRIVER_PREFIX.data(),
           .size = HAL_DRIVER_PREFIX.size(),
       },
-      &host_cpu_deps_.task_params, /*queue_count=*/1, &host_cpu_deps_.executor,
+      &host_cpu_deps_.task_params, /*queue_count=*/queue_executors.size(),
+      reinterpret_cast<iree_task_executor_t **>(queue_executors.data()),
       host_cpu_deps_.loader_count, host_cpu_deps_.loaders,
       host_cpu_deps_.device_allocator, host_allocator(), driver.for_output()));
   unowned_driver = driver.get();
@@ -124,24 +190,31 @@ void HostCPUSystemBuilder::InitializeHostCPUDevices(System &lsys,
   iree::allocated_ptr<iree_hal_device_info_t> device_infos(host_allocator());
   SHORTFIN_THROW_IF_ERROR(iree_hal_driver_query_available_devices(
       driver, host_allocator(), &device_info_count, &device_infos));
+  if (device_info_count != 1) {
+    throw std::logic_error("Expected a single CPU device");
+  }
 
-  for (iree_host_size_t i = 0; i < device_info_count; ++i) {
-    iree::hal_device_ptr device;
-    iree_hal_device_info_t *it = &device_infos.get()[i];
-    SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
-        driver, it->device_id, 0, nullptr, host_allocator(),
-        device.for_output()));
+  iree::hal_device_ptr device;
+  iree_hal_device_info_t *it = &device_infos.get()[0];
+  SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
+      driver, it->device_id, 0, nullptr, host_allocator(),
+      device.for_output()));
+  iree_host_size_t queue_index = 0;
+  for (auto node_id : queue_node_ids_) {
     lsys.InitializeHalDevice(std::make_unique<HostCPUDevice>(
         DeviceAddress(
             /*system_device_class=*/SYSTEM_DEVICE_CLASS,
             /*logical_device_class=*/LOGICAL_DEVICE_CLASS,
             /*hal_driver_prefix=*/HAL_DRIVER_PREFIX,
-            /*instance_ordinal=*/i,
-            /*queue_ordinal=*/0,
-            /*instance_topology_address=*/{0}),
+            /*instance_ordinal=*/0,
+            /*queue_ordinal=*/queue_index,
+            /*instance_topology_address=*/{queue_index}),
         /*hal_device=*/std::move(device),
-        /*node_affinity=*/0,
-        /*node_locked=*/false));
+        /*node_affinity=*/node_id,
+        /*capabilities=*/
+        static_cast<int32_t>(
+            Device::Capabilities::PREFER_HOST_UNIFIED_MEMORY)));
+    queue_index += 1;
   }
 }
 

--- a/libshortfin/src/shortfin/local/systems/host.h
+++ b/libshortfin/src/shortfin/local/systems/host.h
@@ -12,6 +12,7 @@
 #include "iree/task/api.h"
 #include "shortfin/local/system.h"
 #include "shortfin/support/api.h"
+#include "shortfin/support/config.h"
 
 namespace shortfin::local::systems {
 
@@ -32,7 +33,8 @@ class SHORTFIN_API HostSystemBuilder : public SystemBuilder {
 // can extend this class (or provide features themselves).
 class SHORTFIN_API HostCPUSystemBuilder : public HostSystemBuilder {
  public:
-  HostCPUSystemBuilder(iree_allocator_t host_allocator);
+  HostCPUSystemBuilder(iree_allocator_t host_allocator,
+                       ConfigOptions options = {});
   HostCPUSystemBuilder() : HostCPUSystemBuilder(iree_allocator_system()) {}
   ~HostCPUSystemBuilder() override;
 
@@ -54,15 +56,17 @@ class SHORTFIN_API HostCPUSystemBuilder : public HostSystemBuilder {
   struct Deps {
     Deps(iree_allocator_t host_allocator);
     ~Deps();
-    iree_task_topology_t task_topology_options;
     iree_task_executor_options_t task_executor_options;
     iree_hal_task_device_params_t task_params;
     iree_hal_executable_plugin_manager_t* plugin_manager = nullptr;
     iree_hal_executable_loader_t* loaders[8] = {nullptr};
     iree_host_size_t loader_count = 0;
-    iree_task_executor_t* executor = nullptr;
     iree_hal_allocator_t* device_allocator = nullptr;
   } host_cpu_deps_;
+
+ private:
+  std::vector<iree_host_size_t> queue_node_ids_;
+  std::vector<iree_host_size_t> SelectHostCPUNodesFromOptions();
 };
 
 }  // namespace shortfin::local::systems

--- a/libshortfin/src/shortfin/support/CMakeLists.txt
+++ b/libshortfin/src/shortfin/support/CMakeLists.txt
@@ -10,6 +10,7 @@ shortfin_cc_component(
   HDRS
     api.h
     blocking_executor.h
+    config.h
     globals.h
     iree_helpers.h
     iree_concurrency.h
@@ -17,6 +18,7 @@ shortfin_cc_component(
     stl_extras.h
   SRCS
     blocking_executor.cc
+    config.cc
     globals.cc
     iree_helpers.cc
     logging.cc
@@ -31,6 +33,7 @@ shortfin_cc_component(
     iree_io_parameter_index_provider
     iree_io_parameter_provider
     iree_modules_hal_types
+    iree_task_api
     spdlog::spdlog
 )
 

--- a/libshortfin/src/shortfin/support/config.cc
+++ b/libshortfin/src/shortfin/support/config.cc
@@ -1,0 +1,123 @@
+// Copyright 2024 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/config.h"
+
+#include <charconv>
+#include <cstdlib>
+
+#include "fmt/format.h"
+#include "shortfin/support/logging.h"
+
+namespace shortfin {
+
+void ConfigOptions::SetOption(std::string_view key, std::string value) {
+  options_[intern_.intern(key)] = std::move(value);
+}
+
+const std::optional<std::string_view> ConfigOptions::GetOption(
+    std::string_view key) const {
+  // Get explicit option.
+  auto found_it = options_.find(key);
+  if (found_it != options_.end()) {
+    consumed_keys_.insert(key);
+    return found_it->second;
+  }
+
+  // Consult environment.
+  if (env_lookup_prefix_) {
+    std::string env_key;
+    env_key.reserve(env_lookup_prefix_->size() + key.size());
+    env_key.append(*env_lookup_prefix_);
+    for (char c : key) {
+      env_key.push_back(std::toupper(c));
+    }
+    char *env_value = std::getenv(env_key.c_str());
+    if (env_value) {
+      return intern_.intern(env_value);
+    }
+  }
+
+  return {};
+}
+
+std::optional<int64_t> ConfigOptions::GetInt(std::string_view key,
+                                             bool non_negative) const {
+  auto value = GetOption(key);
+  if (!value) return {};
+  int64_t result;
+  auto last = value->data() + value->size();
+  auto err = std::from_chars(value->data(), last, result);
+  if (err.ec != std::errc{} || err.ptr != last) {
+    throw std::invalid_argument(
+        fmt::format("Could not parse '{}' as an integer from config option "
+                    "{}",
+                    *value, key));
+  }
+  if (non_negative && result < 0) {
+    throw std::invalid_argument(fmt::format(
+        "Could not parse '{}' as a non-negative integer from config option "
+        "{}",
+        *value, key));
+  }
+  return result;
+}
+
+std::optional<std::vector<int64_t>> ConfigOptions::GetIntList(
+    std::string_view key, bool non_negative) const {
+  auto value = GetOption(key);
+  if (!value) return {};
+
+  std::vector<int64_t> results;
+  auto Consume = [&](std::string_view atom) {
+    int64_t result;
+    auto last = atom.data() + atom.size();
+    auto err = std::from_chars(atom.data(), last, result);
+    if (err.ec != std::errc{} || err.ptr != last) {
+      throw std::invalid_argument(
+          fmt::format("Could not parse '{}' as an integer from config option "
+                      "{} (full value: {})",
+                      atom, key, *value));
+    }
+    if (non_negative && result < 0) {
+      throw std::invalid_argument(fmt::format(
+          "Could not parse '{}' as a non-negative integer from config option "
+          "{} (full value: {})",
+          atom, key, *value));
+    }
+    results.push_back(result);
+  };
+  std::string_view sv_value = *value;
+  for (;;) {
+    auto found_it = sv_value.find(',');
+    if (found_it == std::string_view::npos) {
+      Consume(sv_value);
+      break;
+    }
+
+    Consume(sv_value.substr(0, found_it));
+    sv_value.remove_prefix(found_it + 1);
+  }
+
+  return results;
+}
+
+void ConfigOptions::CheckAllOptionsConsumed() const {
+  std::vector<std::string_view> unused_options;
+  for (auto it : options_) {
+    const auto &key = it.first;
+    if (!consumed_keys_.contains(key)) {
+      unused_options.push_back(key);
+    }
+  }
+  if (!unused_options.empty()) {
+    throw std::invalid_argument(
+        fmt::format("Specified options were not used: {}",
+                    fmt::join(unused_options, ", ")));
+  }
+}
+
+}  // namespace shortfin

--- a/libshortfin/src/shortfin/support/config.cc
+++ b/libshortfin/src/shortfin/support/config.cc
@@ -35,10 +35,8 @@ const std::optional<std::string_view> ConfigOptions::GetOption(
     for (char c : key) {
       env_key.push_back(std::toupper(c));
     }
-    logging::debug("LOOKUP KEY {}", env_key);
     char *env_value = std::getenv(env_key.c_str());
     if (env_value && std::strlen(env_value) > 0) {
-      logging::debug("LOOKUP KEY {} = {}", env_key, env_value);
       return intern_.intern(env_value);
     }
   }

--- a/libshortfin/src/shortfin/support/config.cc
+++ b/libshortfin/src/shortfin/support/config.cc
@@ -35,8 +35,10 @@ const std::optional<std::string_view> ConfigOptions::GetOption(
     for (char c : key) {
       env_key.push_back(std::toupper(c));
     }
+    logging::debug("LOOKUP KEY {}", env_key);
     char *env_value = std::getenv(env_key.c_str());
-    if (env_value) {
+    if (env_value && std::strlen(env_value) > 0) {
+      logging::debug("LOOKUP KEY {} = {}", env_key, env_value);
       return intern_.intern(env_value);
     }
   }

--- a/libshortfin/src/shortfin/support/config.h
+++ b/libshortfin/src/shortfin/support/config.h
@@ -1,0 +1,70 @@
+// Copyright 2024 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SHORTFIN_SUPPORT_CONFIG_H
+#define SHORTFIN_SUPPORT_CONFIG_H
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "shortfin/support/api.h"
+#include "shortfin/support/stl_extras.h"
+
+namespace shortfin {
+
+// Utility class for querying free-form config options from a string list,
+// environment variables, etc.
+//
+// Config options are looked up in a dict-like map. If not found explicitly,
+// they can be optionally found in the environment if |env_lookup_prefix| is
+// provided. In this case, the requested upper-cased key is concatted to the
+// prefix and lookup up via std::getenv().
+class SHORTFIN_API ConfigOptions {
+ public:
+  ConfigOptions(std::optional<std::string> env_lookup_prefix = {})
+      : env_lookup_prefix_(std::move(env_lookup_prefix)) {}
+  ConfigOptions(const ConfigOptions &) = delete;
+  ConfigOptions(ConfigOptions &&) = default;
+
+  void SetOption(std::string_view key, std::string value);
+
+  const std::optional<std::string_view> GetOption(std::string_view key) const;
+
+  // Gets an option as an integer, optionall enforcing that each is
+  // non-negative.
+  std::optional<int64_t> GetInt(std::string_view key,
+                                bool non_negative = false) const;
+
+  // Gets an option as a list of integers, optionally enforcing that each
+  // is non-negative.
+  std::optional<std::vector<int64_t>> GetIntList(
+      std::string_view key, bool non_negative = false) const;
+
+  // Raises a descriptive invalid_argument exception if options were provided
+  // that were not consulted. This only applies to options added via SetOption
+  // and not environment variables. Use in APIs that expect specific options.
+  void CheckAllOptionsConsumed() const;
+
+ private:
+  mutable string_interner intern_;
+  // Optional environment variable lookup prefix for resolving options not
+  // explicitly set.
+  std::optional<std::string> env_lookup_prefix_;
+
+  // Explicit keyword options.
+  std::unordered_map<std::string_view, std::string> options_;
+
+  // Keep track of which keys were consumed. Used for error checking.
+  mutable std::unordered_set<std::string_view> consumed_keys_;
+};
+
+}  // namespace shortfin
+
+#endif  // SHORTFIN_SUPPORT_CONFIG_H

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -15,6 +15,7 @@
 #include "iree/hal/api.h"
 #include "iree/io/parameter_index_provider.h"
 #include "iree/modules/hal/types.h"
+#include "iree/task/api.h"
 #include "iree/vm/api.h"
 #include "iree/vm/ref_cc.h"
 #include "shortfin/support/api.h"
@@ -144,24 +145,25 @@ class object_ptr {
 // Defines a reference counting helper struct named like
 // iree_hal_buffer_ptr_helper (for type_stem == hal_buffer).
 // These must be defined in the shortfin::iree::detail namespace.
-#define SHORTFIN_IREE_DEF_PTR(type_stem)             \
-  namespace detail {                                 \
-  struct type_stem##_ptr_helper {                    \
-    static void steal(iree_##type_stem##_t *obj) {   \
-      LogIREESteal(#type_stem "_t", obj);            \
-    }                                                \
-    static void retain(iree_##type_stem##_t *obj) {  \
-      LogIREERetain(#type_stem "_t", obj);           \
-      iree_##type_stem##_retain(obj);                \
-    }                                                \
-    static void release(iree_##type_stem##_t *obj) { \
-      LogIREERelease(#type_stem "_t", obj);          \
-      iree_##type_stem##_release(obj);               \
-    }                                                \
-  };                                                 \
-  }                                                  \
-  using type_stem##_ptr =                            \
-      object_ptr<iree_##type_stem##_t, detail::type_stem##_ptr_helper>
+#define SHORTFIN_IREE_DEF_PTR(type_stem)                                \
+  namespace detail {                                                    \
+  struct type_stem##_ptr_helper {                                       \
+    static void steal(iree_##type_stem##_t *obj) {                      \
+      LogIREESteal(#type_stem "_t", obj);                               \
+    }                                                                   \
+    static void retain(iree_##type_stem##_t *obj) {                     \
+      LogIREERetain(#type_stem "_t", obj);                              \
+      iree_##type_stem##_retain(obj);                                   \
+    }                                                                   \
+    static void release(iree_##type_stem##_t *obj) {                    \
+      LogIREERelease(#type_stem "_t", obj);                             \
+      iree_##type_stem##_release(obj);                                  \
+    }                                                                   \
+  };                                                                    \
+  }                                                                     \
+  using type_stem##_ptr =                                               \
+      object_ptr<iree_##type_stem##_t, detail::type_stem##_ptr_helper>; \
+  static_assert(sizeof(type_stem##_ptr) == sizeof(iree_##type_stem##_t *))
 
 SHORTFIN_IREE_DEF_PTR(hal_command_buffer);
 SHORTFIN_IREE_DEF_PTR(hal_buffer);
@@ -173,6 +175,7 @@ SHORTFIN_IREE_DEF_PTR(hal_semaphore);
 SHORTFIN_IREE_DEF_PTR(io_file_handle);
 SHORTFIN_IREE_DEF_PTR(io_parameter_index);
 SHORTFIN_IREE_DEF_PTR(io_parameter_provider);
+SHORTFIN_IREE_DEF_PTR(task_executor);
 SHORTFIN_IREE_DEF_PTR(vm_context);
 SHORTFIN_IREE_DEF_PTR(vm_instance);
 SHORTFIN_IREE_DEF_PTR(vm_list);

--- a/libshortfin/tests/conftest.py
+++ b/libshortfin/tests/conftest.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import os
 import pytest
 
 import shortfin as sf
@@ -34,6 +35,27 @@ def pytest_runtest_setup(item):
                 f"test requires system in {required_system_names!r} but has "
                 f"{available_system_names!r} (set with --system arg)"
             )
+
+
+# Keys that will be cleaned project wide prior to and after each test run.
+# Test code can freely modify these.
+CLEAN_ENV_KEYS = [
+    "SHORTFIN_HOSTCPU_TOPOLOGY_NODES",
+    "SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    def kill():
+        for key in CLEAN_ENV_KEYS:
+            if key in os.environ:
+                del os.environ[key]
+                os.unsetenv(key)
+
+    kill()
+    yield
+    kill()
 
 
 @pytest.fixture

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -4,9 +4,24 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import os
 import pytest
 
 import shortfin as sf
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    save = {}
+    def kill():
+        for key, value in os.environ.items():
+            if key.startswith("SHORTFIN_"):
+                save[key] = value
+                del os.environ[key]
+    kill()
+    yield
+    kill()
+    for key, value in save.items():
+        os.environ[key] = value
 
 
 def test_create_host_cpu_system_defaults():
@@ -31,6 +46,16 @@ def test_create_host_cpu_system_topology_nodes_explicit():
     sc = sf.host.CPUSystemBuilder(
         hostcpu_topology_nodes="0,0", hostcpu_topology_max_group_count=2
     )
+    with sc.create_system() as ls:
+        print(f"LOCAL SYSTEM:", ls)
+        print("\n".join(repr(d) for d in ls.devices))
+        assert len(ls.devices) == 2
+
+
+def test_create_host_cpu_system_env_vars():
+    os.putenv("SHORTFIN_HOSTCPU_TOPOLOGY_NODES", "0,0")
+    os.putenv("SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT", "2")
+    sc = sf.host.CPUSystemBuilder()
     with sc.create_system() as ls:
         print(f"LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -9,14 +9,17 @@ import pytest
 
 import shortfin as sf
 
+
 @pytest.fixture(autouse=True)
 def clean_env():
     save = {}
+
     def kill():
         for key, value in os.environ.items():
             if key.startswith("SHORTFIN_"):
                 save[key] = value
                 del os.environ[key]
+
     kill()
     yield
     kill()

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import pytest
+
 import shortfin as sf
 
 
@@ -12,12 +14,32 @@ def test_create_host_cpu_system_defaults():
     with sc.create_system() as ls:
         print(f"LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
+        assert len(ls.devices) > 0
 
 
-def test_create_host_cpu_system_explicit_topology():
+def test_create_host_cpu_system_topology_nodes_all():
     sc = sf.host.CPUSystemBuilder(
         hostcpu_topology_nodes="all", hostcpu_topology_max_group_count=2
     )
     with sc.create_system() as ls:
         print(f"LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
+        assert len(ls.devices) > 0
+
+
+def test_create_host_cpu_system_topology_nodes_explicit():
+    sc = sf.host.CPUSystemBuilder(
+        hostcpu_topology_nodes="0,0", hostcpu_topology_max_group_count=2
+    )
+    with sc.create_system() as ls:
+        print(f"LOCAL SYSTEM:", ls)
+        print("\n".join(repr(d) for d in ls.devices))
+        assert len(ls.devices) == 2
+
+
+def test_create_host_cpu_system_unsupported_option():
+    sc = sf.host.CPUSystemBuilder(unsupported="foobar")
+    with pytest.raises(
+        ValueError, match="Specified options were not used: unsupported"
+    ):
+        sc.create_system()

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -10,23 +10,6 @@ import pytest
 import shortfin as sf
 
 
-@pytest.fixture(autouse=True)
-def clean_env():
-    save = {}
-
-    def kill():
-        for key, value in os.environ.items():
-            if key.startswith("SHORTFIN_"):
-                save[key] = value
-                del os.environ[key]
-
-    kill()
-    yield
-    kill()
-    for key, value in save.items():
-        os.environ[key] = value
-
-
 def test_create_host_cpu_system_defaults():
     sc = sf.host.CPUSystemBuilder()
     with sc.create_system() as ls:
@@ -56,8 +39,8 @@ def test_create_host_cpu_system_topology_nodes_explicit():
 
 
 def test_create_host_cpu_system_env_vars():
-    os.putenv("SHORTFIN_HOSTCPU_TOPOLOGY_NODES", "0,0")
-    os.putenv("SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT", "2")
+    os.environ["SHORTFIN_HOSTCPU_TOPOLOGY_NODES"] = "0,0"
+    os.environ["SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT"] = "2"
     sc = sf.host.CPUSystemBuilder()
     with sc.create_system() as ls:
         print(f"ENV VARS LOCAL SYSTEM:", ls)

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -4,13 +4,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import shortfin as sf
 
-def test_create_host_cpu_system():
-    from _shortfin import lib as sfl
 
-    sc = sfl.local.host.CPUSystemBuilder()
-    ls = sc.create_system()
-    print(f"LOCAL SYSTEM:", ls)
+def test_create_host_cpu_system_defaults():
+    sc = sf.host.CPUSystemBuilder()
+    with sc.create_system() as ls:
+        print(f"LOCAL SYSTEM:", ls)
+        print("\n".join(repr(d) for d in ls.devices))
 
-    print("Sleeping in Python")
-    ls.shutdown()
+
+def test_create_host_cpu_system_explicit_topology():
+    sc = sf.host.CPUSystemBuilder(
+        hostcpu_topology_nodes="all", hostcpu_topology_max_group_count=2
+    )
+    with sc.create_system() as ls:
+        print(f"LOCAL SYSTEM:", ls)
+        print("\n".join(repr(d) for d in ls.devices))

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -30,7 +30,7 @@ def clean_env():
 def test_create_host_cpu_system_defaults():
     sc = sf.host.CPUSystemBuilder()
     with sc.create_system() as ls:
-        print(f"LOCAL SYSTEM:", ls)
+        print(f"DEFAULT LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
         assert len(ls.devices) > 0
 
@@ -40,7 +40,7 @@ def test_create_host_cpu_system_topology_nodes_all():
         hostcpu_topology_nodes="all", hostcpu_topology_max_group_count=2
     )
     with sc.create_system() as ls:
-        print(f"LOCAL SYSTEM:", ls)
+        print(f"NODES ALL LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
         assert len(ls.devices) > 0
 
@@ -50,7 +50,7 @@ def test_create_host_cpu_system_topology_nodes_explicit():
         hostcpu_topology_nodes="0,0", hostcpu_topology_max_group_count=2
     )
     with sc.create_system() as ls:
-        print(f"LOCAL SYSTEM:", ls)
+        print(f"NODES EXPLICIT LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
         assert len(ls.devices) == 2
 
@@ -60,7 +60,7 @@ def test_create_host_cpu_system_env_vars():
     os.putenv("SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT", "2")
     sc = sf.host.CPUSystemBuilder()
     with sc.create_system() as ls:
-        print(f"LOCAL SYSTEM:", ls)
+        print(f"ENV VARS LOCAL SYSTEM:", ls)
         print("\n".join(repr(d) for d in ls.devices))
         assert len(ls.devices) == 2
 

--- a/libshortfin/tests/local_scope_test.py
+++ b/libshortfin/tests/local_scope_test.py
@@ -58,7 +58,7 @@ def test_devices_collection_access(fiber):
 def test_device_affinity_repr(fiber):
     assert (
         repr(sfl.local.DeviceAffinity(fiber.raw_device(0)))
-        == "DeviceAffinity(host-cpu:0:0@0[0x1])"
+        == "DeviceAffinity(hostcpu:0:0@0[0x1])"
     )
     assert repr(sfl.local.DeviceAffinity()) == "DeviceAffinity(ANY)"
 


### PR DESCRIPTION
On NUMA systems, a NUMA node maps to a device queue, which manifests as a Shortfin Device. On non-NUMA systems, options can be used to control the concurrency.

Also drops the `Device::node_locked` field and replaces it with `capabilities`, which is needed in order to create better data transfer APIs.