### PR TITLE
Set linking mode to static by default on Windows.

### DIFF
--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -43,8 +43,16 @@ option(SHORTFIN_ENABLE_TRACING "Enable runtime tracing for iree and shortfin" OF
 set(SHORTFIN_IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Options for building static or dynamic libraries.
-option(SHORTFIN_BUILD_STATIC "Builds static libraries" OFF)
-option(SHORTFIN_BUILD_DYNAMIC "Builds dynamic libraries" ON)
+# Default to dynamic linking, unless on Windows.
+# TODO(#211): Unify the defaults once Windows dynamic linking issues are fixed.
+set(SHORTFIN_BUILD_STATIC_DEFAULT OFF)
+set(SHORTFIN_BUILD_DYNAMIC_DEFAULT ON)
+if(WIN32)
+  set(SHORTFIN_BUILD_STATIC_DEFAULT ON)
+  set(SHORTFIN_BUILD_DYNAMIC_DEFAULT OFF)
+endif()
+option(SHORTFIN_BUILD_STATIC "Builds static libraries" ${SHORTFIN_BUILD_STATIC_DEFAULT})
+option(SHORTFIN_BUILD_DYNAMIC "Builds dynamic libraries" ${SHORTFIN_BUILD_DYNAMIC_DEFAULT})
 cmake_dependent_option(SHORTFIN_LINK_DYNAMIC "Links internal binaries against static libshortfin.a" ON "SHORTFIN_BUILD_DYNAMIC" OFF)
 if(NOT SHORTFIN_BUILD_STATIC AND NOT SHORTFIN_BUILD_DYNAMIC)
   message(FATAL_ERROR "One of SHORTFIN_BUILD_STATIC or SHORTFIN_BUILD_DYNAMIC must be ON")


### PR DESCRIPTION
This is a workaround for https://github.com/nod-ai/SHARK-Platform/issues/211 while I/we find a way to enable dynamic linking builds on Windows.

With this and https://github.com/nod-ai/SHARK-Platform/pull/210, I can configure and build libshortfin on Windows using default CMake options and the CMake that `pip install -v -e .` runs internally. The local package build passes an initial smoketest too (can run `import shortfin` and poke around in the python interpreter).