### PR TITLE
[libshortfin] Add a workflow with disabled GIL

### DIFF
--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -1,0 +1,97 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: CI - libshortfin - GIL disabled
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci_linux_x64-libshortfin.yml'
+      - 'libshortfin/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  IREE_REPO_DIR: ${{ github.workspace }}/iree
+  LIBSHORTFIN_DIR: ${{ github.workspace }}/libshortfin/
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install clang lld cmake ninja-build
+
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        submodules: false
+
+    - name: Checkout IREE repo
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: iree-org/iree
+        path: ${{ env.IREE_REPO_DIR }}
+        submodules: false
+        ref: candidate-20240904.1006
+
+    - name: Initalize IREE submodules
+      run : |
+        cd ${{ env.IREE_REPO_DIR }}
+        git submodule update --init --depth 1 -- third_party/benchmark
+        git submodule update --init --depth 1 -- third_party/cpuinfo/
+        git submodule update --init --depth 1 -- third_party/flatcc
+        git submodule update --init --depth 1 -- third_party/googletest
+        git submodule update --init --depth 1 -- third_party/hip-build-deps/
+
+    - name: Setup Python
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
+      with:
+        python-version: "3.13-dev"
+        nogil : true
+    - name: Install Python packages
+      run: |
+        pip install -r ${{ env.LIBSHORTFIN_DIR }}/requirements-tests-nogil.txt
+        pip freeze
+
+    - name: Build libshortfin (full)
+      run: |
+        mkdir ${{ env.LIBSHORTFIN_DIR }}/build
+        cd ${{ env.LIBSHORTFIN_DIR }}/build
+        cmake -GNinja \
+          -DCMAKE_C_COMPILER=clang-18 \
+          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DCMAKE_LINKER_TYPE=LLD \
+          -DSHORTFIN_BUNDLE_DEPS=ON \
+          -DSHORTFIN_IREE_SOURCE_DIR=${{ env.IREE_REPO_DIR }} \
+          -DSHORTFIN_BUILD_PYTHON_BINDINGS=ON \
+          ..
+        cmake --build . --target all
+        pip install -v -e .
+
+    - name: Run libshortfin Python tests (full)
+      run: |
+        cd ${{ env.LIBSHORTFIN_DIR }}
+        pytest -s --ignore=tests/examples/fastapi_test.py
+      # TODO: Enable further tests and switch to
+      # pytest -s tests

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: CI - libshortfin - GIL disabled
+name: CI - libshortfin - Python 3.13 Free-threaded
 
 on:
   workflow_dispatch:

--- a/libshortfin/requirements-tests-nogil.txt
+++ b/libshortfin/requirements-tests-nogil.txt
@@ -1,0 +1,4 @@
+pytest
+requests
+fastapi
+uvicorn


### PR DESCRIPTION
This adds a seperate, and therefore temporary, workflow to run with a free-threaded Python which should be embedded into a matrix strategy.

To fully enable testing without the GIL, it is required to declare that `_shortfin_default.lib` can either be safley run without it or to run with `PYTHON_GIL=0`.