### PR TITLE
[shortfin] Make system construction selectable by type name.

### DIFF
--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -98,7 +98,6 @@ option(SHORTFIN_SYSTEMS_AMDGPU "Builds for AMD GPU systems" ON)
 message(STATUS "libshortfin supported systems:")
 if(SHORTFIN_SYSTEMS_AMDGPU)
   message(STATUS "  - AMD GPU")
-  add_compile_definitions("SHORTFIN_HAVE_AMDGPU")
 endif()
 message(STATUS "  - Host")
 

--- a/libshortfin/build_tools/cmake/shortfin_library.cmake
+++ b/libshortfin/build_tools/cmake/shortfin_library.cmake
@@ -53,7 +53,7 @@ function(shortfin_cc_component)
     _RULE
     ""
     "NAME"
-    "HDRS;SRCS;DEPS;COMPONENTS"
+    "HDRS;SRCS;DEFINES;DEPS;COMPONENTS"
     ${ARGN}
   )
   if(SHORTFIN_BUILD_STATIC)
@@ -73,6 +73,7 @@ function(shortfin_cc_component)
         ${_STATIC_COMPONENTS}
         ${_RULE_DEPS}
     )
+    target_compile_definitions(${_STATIC_OBJECTS_NAME} PUBLIC ${_RULE_DEFINES})
   endif()
 
   if(SHORTFIN_BUILD_DYNAMIC)
@@ -101,6 +102,7 @@ function(shortfin_cc_component)
     )
     target_compile_definitions(${_DYLIB_OBJECTS_NAME}
       PRIVATE _SHORTFIN_BUILDING_DYLIB)
+    target_compile_definitions(${_DYLIB_OBJECTS_NAME} PUBLIC ${_RULE_DEFINES})
   endif()
 endfunction()
 

--- a/libshortfin/src/CMakeLists.txt
+++ b/libshortfin/src/CMakeLists.txt
@@ -13,11 +13,10 @@ target_include_directories(
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 
-set(_INIT_INTERNAL_DEPS)
-if(SHORTFIN_SYSTEMS_AMDGPU)
-  list(APPEND _INIT_INTERNAL_DEPS shortfin_systems_amdgpu)
-endif()
+get_property(
+  _SHORTFIN_LIB_OPTIONAL_COMPONENTS GLOBAL PROPERTY SHORTFIN_LIB_OPTIONAL_COMPONENTS)
 
+message(STATUS "Linking optional components ${_SHORTFIN_LIB_OPTIONAL_COMPONENTS}")
 shortfin_public_library(
   NAME
     shortfin
@@ -25,6 +24,6 @@ shortfin_public_library(
     shortfin_array
     shortfin_local
     shortfin_support
-    shortfin_systems_host
-    ${_INIT_INTERNAL_DEPS}
+    shortfin_systems_factory
+    ${_SHORTFIN_LIB_OPTIONAL_COMPONENTS}
 )

--- a/libshortfin/src/CMakeLists.txt
+++ b/libshortfin/src/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(
 get_property(
   _SHORTFIN_LIB_OPTIONAL_COMPONENTS GLOBAL PROPERTY SHORTFIN_LIB_OPTIONAL_COMPONENTS)
 
-message(STATUS "Linking optional components ${_SHORTFIN_LIB_OPTIONAL_COMPONENTS}")
+message(STATUS "Linking optional components '${_SHORTFIN_LIB_OPTIONAL_COMPONENTS}'")
 shortfin_public_library(
   NAME
     shortfin

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -83,6 +83,15 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   System(const System &) = delete;
   ~System();
 
+  // One shot creation factory that is the equivalent of:
+  //   SystemBuilder::ForSystem(
+  //     host_allocator, system_type,
+  //     std::move(config_options))->CreateSystem()
+  // Undef validation will be done on the config options prior to returning.
+  static std::shared_ptr<System> Create(iree_allocator_t host_allocator,
+                                        std::string_view system_type,
+                                        ConfigOptions config_options = {});
+
   // Explicit shutdown (vs in destructor) is encouraged.
   void Shutdown();
 
@@ -227,6 +236,12 @@ class SHORTFIN_API SystemBuilder {
         config_options_(std::move(config_options)) {}
   SystemBuilder() : SystemBuilder(iree_allocator_system()) {}
   virtual ~SystemBuilder() = default;
+
+  // Creates a SystemBuilder subclass for a given named system (i.e.
+  // "hostcpu", "amdgpu", etc).
+  static std::unique_ptr<SystemBuilder> ForSystem(
+      iree_allocator_t host_allocator, std::string_view system_type,
+      ConfigOptions config_options = {});
 
   iree_allocator_t host_allocator() { return host_allocator_; }
   const ConfigOptions &config_options() const { return config_options_; }

--- a/libshortfin/src/shortfin/local/systems/CMakeLists.txt
+++ b/libshortfin/src/shortfin/local/systems/CMakeLists.txt
@@ -4,6 +4,8 @@
 # https://llvm.org/LICENSE.txt for license information. SPDX-License-Identifier:
 # Apache-2.0 WITH LLVM-exception
 
+set(_SYSTEM_COMPONENTS)
+
 shortfin_cc_component(
   NAME
     shortfin_systems_host
@@ -14,6 +16,8 @@ shortfin_cc_component(
   COMPONENTS
     shortfin_local
     shortfin_support
+  DEFINES
+    SHORTFIN_HAVE_HOSTCPU
   DEPS
     iree_hal_drivers_local_task_task_driver
     iree_hal_local_executable_loader
@@ -24,17 +28,35 @@ shortfin_cc_component(
     iree_task_api
     iree_task_task
 )
+list(APPEND _SYSTEM_COMPONENTS shortfin_systems_host)
+
+if(SHORTFIN_SYSTEMS_AMDGPU)
+  shortfin_cc_component(
+    NAME
+      shortfin_systems_amdgpu
+    HDRS
+      amdgpu.h
+    SRCS
+      amdgpu.cc
+    DEFINES
+      SHORTFIN_HAVE_AMDGPU
+    COMPONENTS
+      shortfin_local
+      shortfin_support
+    DEPS
+      iree_hal_drivers_hip_hip
+  )
+  list(APPEND _SYSTEM_COMPONENTS shortfin_systems_amdgpu)
+endif()
 
 shortfin_cc_component(
   NAME
-    shortfin_systems_amdgpu
-  HDRS
-    amdgpu.h
+    shortfin_systems_factory
   SRCS
-    amdgpu.cc
+    factory.cc
   COMPONENTS
-    shortfin_local
-    shortfin_support
-  DEPS
-    iree_hal_drivers_hip_hip
+    ${_SYSTEM_COMPONENTS}
 )
+
+set_property(GLOBAL APPEND
+  PROPERTY SHORTFIN_LIB_OPTIONAL_COMPONENTS ${_SYSTEM_COMPONENTS})

--- a/libshortfin/src/shortfin/local/systems/factory.cc
+++ b/libshortfin/src/shortfin/local/systems/factory.cc
@@ -1,0 +1,79 @@
+// Copyright 2024 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/local/system.h"
+#include "shortfin/support/logging.h"
+
+#ifdef SHORTFIN_HAVE_HOSTCPU
+#include "shortfin/local/systems/host.h"
+#endif
+
+#ifdef SHORTFIN_HAVE_AMDGPU
+#include "shortfin/local/systems/amdgpu.h"
+#endif
+
+namespace shortfin::local {
+
+SystemPtr System::Create(iree_allocator_t host_allocator,
+                         std::string_view system_type,
+                         ConfigOptions config_options) {
+  auto builder = SystemBuilder::ForSystem(host_allocator, system_type,
+                                          std::move(config_options));
+  auto system = builder->CreateSystem();
+  try {
+    builder->config_options().ValidateUndef();
+  } catch (...) {
+    system->Shutdown();
+    throw;
+  }
+  return system;
+}
+
+std::unique_ptr<SystemBuilder> SystemBuilder::ForSystem(
+    iree_allocator_t host_allocator, std::string_view system_type,
+    ConfigOptions config_options) {
+  using Factory = std::unique_ptr<SystemBuilder> (*)(
+      iree_allocator_t host_allocator, ConfigOptions);
+  static const std::vector<std::pair<std::string_view, Factory>> factories{
+#ifdef SHORTFIN_HAVE_HOSTCPU
+      std::make_pair(
+          "hostcpu",
+          +[](iree_allocator_t host_allocator,
+              ConfigOptions options) -> std::unique_ptr<SystemBuilder> {
+            return std::make_unique<systems::HostCPUSystemBuilder>(
+                host_allocator, std::move(options));
+          }),
+#endif
+#ifdef SHORTFIN_HAVE_AMDGPU
+      std::make_pair(
+          "amdgpu",
+          +[](iree_allocator_t host_allocator,
+              ConfigOptions options) -> std::unique_ptr<SystemBuilder> {
+            return std::make_unique<systems::AMDGPUSystemBuilder>(
+                host_allocator, std::move(options));
+          }),
+#endif
+  };
+
+  for (auto &it : factories) {
+    if (system_type == it.first) {
+      return it.second(host_allocator, std::move(config_options));
+    }
+  }
+
+  // Not found.
+  std::vector<std::string_view> available;
+  available.reserve(factories.size());
+  for (auto &it : factories) {
+    available.push_back(it.first);
+  }
+
+  throw std::invalid_argument(
+      fmt::format("System type '{}' not known (available: {})", system_type,
+                  fmt::join(available, ", ")));
+}
+
+}  // namespace shortfin::local

--- a/libshortfin/src/shortfin/support/config.cc
+++ b/libshortfin/src/shortfin/support/config.cc
@@ -129,7 +129,7 @@ std::optional<std::vector<int64_t>> ConfigOptions::GetIntList(
   return results;
 }
 
-void ConfigOptions::CheckAllOptionsConsumed() const {
+void ConfigOptions::ValidateUndef() const {
   std::vector<std::string_view> unused_options;
   for (auto it : options_) {
     const auto &key = it.first;
@@ -138,9 +138,18 @@ void ConfigOptions::CheckAllOptionsConsumed() const {
     }
   }
   if (!unused_options.empty()) {
-    throw std::invalid_argument(
-        fmt::format("Specified options were not used: {}",
-                    fmt::join(unused_options, ", ")));
+    std::string message = fmt::format("Specified options were not used: {}",
+                                      fmt::join(unused_options, ", "));
+    switch (validation_) {
+      case ValidationLevel::UNDEF_DEBUG:
+        logging::debug("{}", message);
+        break;
+      case ValidationLevel::UNDEF_WARN:
+        logging::warn("{}", message);
+        break;
+      case ValidationLevel::UNDEF_ERROR:
+        throw std::invalid_argument(std::move(message));
+    }
   }
 }
 

--- a/libshortfin/tests/amdgpu_system_test.py
+++ b/libshortfin/tests/amdgpu_system_test.py
@@ -67,3 +67,9 @@ def test_create_amd_gpu_system_visible_unknown():
         match="Requested visible device 'foobar' was not found on the system",
     ):
         sc.create_system()
+
+
+@pytest.mark.system("amdgpu")
+def test_system_ctor():
+    with sf.System("amdgpu") as ls:
+        assert "amdgpu:0:0@0" in ls.device_names

--- a/libshortfin/tests/host_cpu_system_test.py
+++ b/libshortfin/tests/host_cpu_system_test.py
@@ -6,6 +6,7 @@
 
 import os
 import pytest
+import re
 
 import shortfin as sf
 
@@ -54,3 +55,30 @@ def test_create_host_cpu_system_unsupported_option():
         ValueError, match="Specified options were not used: unsupported"
     ):
         sc.create_system()
+
+
+def test_system_ctor():
+    with sf.System(
+        "hostcpu", hostcpu_topology_nodes="0,0", hostcpu_topology_max_group_count=2
+    ) as ls:
+        print(f"NODES EXPLICIT LOCAL SYSTEM:", ls)
+        print("\n".join(repr(d) for d in ls.devices))
+        assert len(ls.devices) == 2
+
+
+def test_system_ctor_unknown_type():
+    with pytest.raises(
+        ValueError,
+        match=re.escape("System type 'NOTDEFINED' not known (available: hostcpu"),
+    ):
+        sf.System("NOTDEFINED")
+
+
+def test_system_ctor_undef_error():
+    with pytest.raises(ValueError, match="Specified options were not used: undef"):
+        sf.System("hostcpu", undef=1)
+
+
+def test_system_ctor_undef_warn():
+    with sf.System("hostcpu", validate_undef=False, undef=1) as ls:
+        ...


### PR DESCRIPTION
Prior usage required callers to switch to know which SystemBuilder class to create. That option of construction is still available and has more explicitness.

This patch adds C++ APIs for construction of a SystemBuilder by type_name and a shorthand on the System class to have a one line create. Also reworks the config undef checking to be consistent and make it possible to warn instead of throw an exception.

In Python, this is exposed by the System class getting a constructor, so now a one-liner like `with sf.System("hostcpu", option1="value", ...):` is possible. This should compose well with flags and application code.