### PR TITLE
[shortfin] Add extras_require for optional deps.

### DIFF
--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -391,7 +391,8 @@ setup(
             "tokenizers",
         ],
         "onnx": [
-            "onnx",
+            "iree-runtime",
+            "iree-compiler[onnx]",
         ],
         "torch": [
             # Note that this pulls in `torch>=2.3.0`, which then pulls in all of CUDA.

--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -381,6 +381,27 @@ setup(
         [CMakeExtension("_shortfin_default.lib")]
         + ([CMakeExtension("_shortfin_tracy.lib")] if ENABLE_TRACY else [])
     ),
+    extras_require={
+        "testing": [
+            "pytest",
+            "requests",
+        ],
+        "apps": [
+            "dataclasses-json",
+            "tokenizers",
+        ],
+        "onnx": [
+            "onnx",
+        ],
+        "torch": [
+            # Note that this pulls in `torch>=2.3.0`, which then pulls in all of CUDA.
+            "iree-turbine",
+        ],
+        "server": [
+            "fastapi",
+            "uvicorn",
+        ],
+    },
     cmdclass={
         "build": CustomBuild,
         "build_ext": NoopBuildExtension,


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-Platform/issues/130

These optional dependencies can be installed with e.g. `pip install {INDEX URL HERE} shortfin[server]`.

* I'm not sure which names we want and with which packages. How many is too many? 5 seems like a lot.
* YMMV with Python 3.13t (free-threaded). Packages that don't yet distribute binaries for 3.13t may need to be built from source, which might require rust or other local tools.

We can share these requirements with `requirements-*.txt` files using this technique, if we want: https://github.com/nod-ai/SHARK-Platform/blob/72665fc0e3e8d1ed3b4e7eacdfa9c493e2ba0852/sharktank/setup.py#L46-L57 https://github.com/nod-ai/SHARK-Platform/blob/72665fc0e3e8d1ed3b4e7eacdfa9c493e2ba0852/sharktank/setup.py#L100-L105

Docs: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html