### PR TITLE
[tuner] Account for different CWD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ wheelhouse
 *.whl
 *.venv
 
-#Model artifacts
+# Model artifacts
 *.pt
 *.safetensors
 *.gguf
 *.vmfb
+
+# Tuner artifacts
+tuning_*/

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -122,8 +122,12 @@ def main():
 
     path_config = libtuner.PathConfig()
     # We expect the configs to be in the same dir as the input.
-    path_config.global_config_prolog_mlir = input_dir / path_config.global_config_prolog_mlir
-    path_config.global_config_epilog_mlir = input_dir / path_config.global_config_epilog_mlir
+    path_config.global_config_prolog_mlir = (
+        input_dir / path_config.global_config_prolog_mlir
+    )
+    path_config.global_config_epilog_mlir = (
+        input_dir / path_config.global_config_epilog_mlir
+    )
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
     path_config.output_unilog.touch()
 

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -12,7 +12,7 @@ python -m tuner.examples.punet benchmark.mlir --lhs-dims=bmk --rhs-dims=bkn --ti
 
 Recommended Trial Run:
 
-python -m tuner.examples.punet benchmark.mlir --num-candidates=1
+python -m tuner.examples.punet benchmark.mlir --num-candidates=10
 
 
 Dry Run Test (no gpu requried):
@@ -118,9 +118,15 @@ class PunetClient(libtuner.TuningClient):
 
 def main():
     args = libtuner.parse_arguments()
+    input_dir = Path(args.input_file).resolve().parent
+
     path_config = libtuner.PathConfig()
+    # We expect the configs to be in the same dir as the input.
+    path_config.global_config_prolog_mlir = input_dir / path_config.global_config_prolog_mlir
+    path_config.global_config_epilog_mlir = input_dir / path_config.global_config_epilog_mlir
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
     path_config.output_unilog.touch()
+
     candidate_trackers: list[libtuner.CandidateTracker] = []
     punet_client = PunetClient()
     stop_after_phase: str = args.stop_after

--- a/tuner/libtuner.py
+++ b/tuner/libtuner.py
@@ -78,12 +78,12 @@ class CandidateTracker:
     calibrated_benchmark_diff: Optional[float] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class PathConfig:
     # Preset constants
-    global_config_prolog_mlir: Path = Path("./config_prolog.mlir")
-    global_config_epilog_mlir: Path = Path("./config_epilog.mlir")
-    model_baseline_vmfb: Path = Path("./baseline.vmfb")
+    global_config_prolog_mlir: Path = Path("config_prolog.mlir")
+    global_config_epilog_mlir: Path = Path("config_epilog.mlir")
+    model_baseline_vmfb: Path = Path("baseline.vmfb")
 
     # Dynamic paths
     base_dir: Path = field(init=False)


### PR DESCRIPTION
Since the default invocation is now in the repo root dir, look for the config files in the same dir as the specified input.

Also add tuning directories to gitignore.