### PR TITLE
Add python3.12 requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Use this as a guide to get started developing the project using pinned,
 pre-release dependencies. You are welcome to deviate as you see fit, but
 these canonical directions mirror what the CI does.
 
+### Requirements
+
+- Python3.12
+
 ### Setup a venv
 
 We recommend setting up a virtual environment (venv). The project is configured


### PR DESCRIPTION
We use the `walk_up` method of PurePath from pathlib that was introduced in python3.12.

I suppose we could also just implement walk_up() manually so we can support more python versions. Not sure if any other pieces will require 3.12