### PR TITLE
[tuner] Use JSON for benchmark output

### DIFF
--- a/tuner/examples/dispatch/dispatch_tuner.py
+++ b/tuner/examples/dispatch/dispatch_tuner.py
@@ -58,6 +58,7 @@ class DispatchTuner(libtuner.TuningClient):
             f"--module={compiled_vmfb_path.resolve()}",
             "--batch_size=1000",
             "--benchmark_repetitions=3",
+            "--benchmark_format=json",
         ]
 
         return command

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -58,8 +58,7 @@ class PunetClient(libtuner.TuningClient):
             "--hip_allow_inline_execution=true",
             "--batch_size=1000",
             "--benchmark_repetitions=3",
-            f"--benchmark_out=dispatch_{candidate_tracker.candidate_id}_bm.json",
-            "--benchmark_out_format=json",
+            "--benchmark_format=json",
         ]
 
         return command
@@ -110,8 +109,7 @@ class PunetClient(libtuner.TuningClient):
             "--input=2x6xf16",
             "--input=1xf16",
             "--benchmark_repetitions=5",
-            f"--benchmark_out=model_{candidate_tracker.candidate_id}_bm.json",
-            "--benchmark_out_format=json",
+            "--benchmark_format=json",
         ]
         return command
 


### PR DESCRIPTION
### Notes
- Adds `extract_benchmark_from_run_result` method to help in fetching the "benchmarks" data
- Updates `IREEBenchmarkResult` model to reflect that the result is no longer stored as string but as a list of benchmarks
- Updates the parsing of dispatches and models to read from Json

### Testing
- Updates tests to verify that `get_mean_time` functions as expected
- Updates tests to verify that Json data is properly parsed and processed