### PR TITLE
Add fp8 quantization for conv and linear layers

### DIFF
--- a/sharktank/sharktank/kernels/batch_matmul_transpose_b.py
+++ b/sharktank/sharktank/kernels/batch_matmul_transpose_b.py
@@ -80,7 +80,7 @@ class batch_matmul_transpose_b(CustomOp):
         spec_sig = f"L{a_ident}_R{b_ident}"
         template_file = "batch_matmul_transpose_b.mlir"
         target_function_name = f"sharktank_batch_matmul_transpose_b_{spec_sig}"
-
+        cst_zero = "0." if "f" in str(accum_type) else "0"
         # Template params.
         c_asm_type = f"tensor<{'x'.join('?' if d is None else str(d) for d in result_desc.spec_dims)}x{accum_type}>"
 
@@ -93,5 +93,6 @@ class batch_matmul_transpose_b(CustomOp):
             b_asm_type=b_asm_type,
             c_asm_type=c_asm_type,
             dtype=str(accum_type),
+            cst_zero=cst_zero,
         )
         kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -23,6 +23,8 @@ _LEGAL_OUTPUT_TYPES = {
     (torch.int16, torch.int16, "torch.int16"): torch.int16,
     (torch.int16, torch.int16, "torch.int32"): torch.int32,
     # Legal fp types.
+    (torch.float8_e4m3fnuz, torch.float8_e4m3fnuz, "torch.float16"): torch.float16,
+    (torch.float8_e4m3fnuz, torch.float8_e4m3fnuz, "torch.float32"): torch.float32,
     (torch.float16, torch.float16, "torch.float16"): torch.float16,
     (torch.float16, torch.float16, "torch.float32"): torch.float32,
     (torch.float32, torch.float32, "torch.float32"): torch.float32,
@@ -33,6 +35,7 @@ _OUTPUT_TYPE_TO_ASM = {
     torch.int8: "i8",
     torch.int16: "i16",
     torch.int32: "i32",
+    torch.float8_e4m3fnuz: "f8E4M3FNUZ",
     torch.float16: "f16",
     torch.float32: "f32",
 }

--- a/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
+++ b/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
@@ -15,7 +15,7 @@ module {
 util.func private @sharktank_batch_matmul_transpose_b_{{spec_sig}}(
     %a: !a_tensor_type, %b: !b_tensor_type)
     -> !c_tensor_type {
-  %zero = arith.constant 0: !dtype
+  %zero = arith.constant 0.: !dtype
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %batch_dim = tensor.dim %a, %c0 : !a_tensor_type  // b, m, k

--- a/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
+++ b/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// !cst_zero = {{cst_zero}}
 !dtype = {{dtype}}
 !a_tensor_type = {{a_asm_type}}
 !b_tensor_type = {{b_asm_type}}
@@ -15,7 +16,8 @@ module {
 util.func private @sharktank_batch_matmul_transpose_b_{{spec_sig}}(
     %a: !a_tensor_type, %b: !b_tensor_type)
     -> !c_tensor_type {
-  %zero = arith.constant 0.: !dtype
+  // %zero = arith.constant !cst_zero: !dtype
+  %zero = arith.constant {{cst_zero}}: !dtype
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %batch_dim = tensor.dim %a, %c0 : !a_tensor_type  // b, m, k

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -208,7 +208,7 @@ def apply_per_layer_quant(
         bias_scale = 1.0 / (input_scale * weight_scale)
         bias_quantizer = StaticScaledQuantizer(
             scale=bias_scale,
-            dtype=torch.int32,
+            dtype=torch.int32 if quantization_dtype == torch.int8 else torch.float16,
             disable_saturate=True,
         )
         bias_quant = bias_quantizer.quantize(bias, name=bias_name)

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -61,10 +61,14 @@ def qconv2d_tensor_scaled(
 
     # # Handle integer and fp8 quantizations.
     if (
-        input_layout.qs.dtype != torch.float8_e4m3fnuz
-        and weight_layout.qs.dtype != torch.float8_e4m3fnuz
+        input_layout.qs.dtype.is_floating_point
+        or weight_layout.qs.dtype.is_floating_point
     ):
-        return NotImplemented
+        if (
+            input_layout.qs.dtype != torch.float8_e4m3fnuz
+            or weight_layout.qs.dtype != torch.float8_e4m3fnuz
+        ):
+            return NotImplemented
 
     # Bias is both optional and may either be quantized or fp.
     bias_qs = None
@@ -270,9 +274,9 @@ def _pad_last_2d(input_tensor, pad_width):
     )
 
     # Copy the values from the input tensor to the appropriate location in the padded tensor
-    padded_tensor[
-        :, :, pad_top : pad_top + height, pad_left : pad_left + width
-    ] = input_tensor
+    padded_tensor[:, :, pad_top : pad_top + height, pad_left : pad_left + width] = (
+        input_tensor
+    )
     return padded_tensor
 
 

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -31,7 +31,7 @@ from .signatures import (
 )
 
 
-def qconv2d_tensor_scaled_integer(
+def qconv2d_tensor_scaled(
     input: QuantizedTensor,
     weight: QuantizedTensor,
     bias: Optional[AnyTensor] = None,
@@ -59,10 +59,10 @@ def qconv2d_tensor_scaled_integer(
     input_layout: TensorScaledLayout = input.unpack()
     weight_layout: TensorScaledLayout = weight.unpack()
 
-    # Only handle integer quantizations.
+    # # Handle integer and fp8 quantizations.
     if (
-        input_layout.qs.dtype.is_floating_point
-        or weight_layout.qs.dtype.is_floating_point
+        input_layout.qs.dtype != torch.float8_e4m3fnuz
+        and weight_layout.qs.dtype != torch.float8_e4m3fnuz
     ):
         return NotImplemented
 
@@ -85,7 +85,10 @@ def qconv2d_tensor_scaled_integer(
 
     # Alias components (d=scale, qs=quantized samples, m=offset).
     if accum_dtype is None:
-        accum_dtype = torch.int32
+        if weight_layout.qs.dtype.is_floating_point:
+            accum_dtype = torch.float32
+        else:
+            accum_dtype = torch.int32
     input_d = input_layout.d
     input_dtype = input_layout.dtype
     input_qs = input_layout.qs
@@ -114,7 +117,7 @@ def qconv2d_tensor_scaled_integer(
     dilation = _expand_int_to_2_tuple(dilation)
     extended_padding_list = [item for item in padding for _ in range(2)]
     padded_input = _pad_last_2d(input_qs, extended_padding_list)
-    y_qs = _invoke_int32_conv2d(
+    y_qs = _invoke_conv2d_kernel(
         padded_input,
         weight_qs,
         bias_qs.to(accum_dtype) if bias_qs is not None else None,
@@ -145,7 +148,7 @@ def qconv2d_tensor_scaled_integer(
         weight_offset_fix = torch.sum(
             padded_input, dim=1, keepdim=True, dtype=accum_dtype
         )
-        weight_offset_fix = _invoke_int32_pooling_sum(
+        weight_offset_fix = _invoke_pooling_sum_kernel(
             weight_offset_fix,
             [weight_qs.shape[2], weight_qs.shape[3]],
             stride,
@@ -188,13 +191,11 @@ def qconv2d_tensor_scaled_integer(
     return y
 
 
-conv2d.override(QuantizedTensor, QuantizedTensor)(qconv2d_tensor_scaled_integer)
-conv2d.override(QuantizedTensor, QuantizedTensor, AnyTensor)(
-    qconv2d_tensor_scaled_integer
-)
+conv2d.override(QuantizedTensor, QuantizedTensor)(qconv2d_tensor_scaled)
+conv2d.override(QuantizedTensor, QuantizedTensor, AnyTensor)(qconv2d_tensor_scaled)
 
 
-def _invoke_int32_conv2d(input, weight, bias, stride, dilation, *, accum_dtype):
+def _invoke_conv2d_kernel(input, weight, bias, stride, dilation, *, accum_dtype):
     """Does a low level invocation of a conv2d integer kernel on an explicitly padded input.
 
     This presumes that the stride/padding/dilation have already been normalized
@@ -233,7 +234,7 @@ def _invoke_int32_conv2d(input, weight, bias, stride, dilation, *, accum_dtype):
     return y_qs
 
 
-def _invoke_int32_pooling_sum(input, kernel_size, stride, dilation, *, accum_dtype):
+def _invoke_pooling_sum_kernel(input, kernel_size, stride, dilation, *, accum_dtype):
     """Invokes either a custom integer pooling sum or the built-in fp avg_pool2d
     kernel on an explicitly padded input.
     """

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -274,9 +274,9 @@ def _pad_last_2d(input_tensor, pad_width):
     )
 
     # Copy the values from the input tensor to the appropriate location in the padded tensor
-    padded_tensor[:, :, pad_top : pad_top + height, pad_left : pad_left + width] = (
-        input_tensor
-    )
+    padded_tensor[
+        :, :, pad_top : pad_top + height, pad_left : pad_left + width
+    ] = input_tensor
     return padded_tensor
 
 

--- a/sharktank/tests/ops/qconv_test.py
+++ b/sharktank/tests/ops/qconv_test.py
@@ -71,7 +71,7 @@ class QConvTest(unittest.TestCase):
         )
         self.assertIs(
             ops._registry._test_get_last_op_dispatch(),
-            ops.qconv_impls.qconv2d_tensor_scaled_integer,
+            ops.qconv_impls.qconv2d_tensor_scaled,
         )
         y_ref = torch.nn.functional.conv2d(
             input_q.unpack().dequant(),
@@ -105,7 +105,7 @@ class QConvTest(unittest.TestCase):
         y_actual = ops.conv2d(input_q, weight_q, bias, stride=1, padding=(1, 1))
         self.assertIs(
             ops._registry._test_get_last_op_dispatch(),
-            ops.qconv_impls.qconv2d_tensor_scaled_integer,
+            ops.qconv_impls.qconv2d_tensor_scaled,
         )
         y_ref = torch.nn.functional.conv2d(
             input_q.unpack().dequant(),
@@ -147,7 +147,7 @@ class QConvTest(unittest.TestCase):
         )
         self.assertIs(
             ops._registry._test_get_last_op_dispatch(),
-            ops.qconv_impls.qconv2d_tensor_scaled_integer,
+            ops.qconv_impls.qconv2d_tensor_scaled,
         )
         y_ref = torch.nn.functional.conv2d(
             input_q.unpack().dequant(),
@@ -184,7 +184,7 @@ class QConvTest(unittest.TestCase):
         )
         self.assertIs(
             ops._registry._test_get_last_op_dispatch(),
-            ops.qconv_impls.qconv2d_tensor_scaled_integer,
+            ops.qconv_impls.qconv2d_tensor_scaled,
         )
         y_ref = torch.nn.functional.conv2d(
             input_q.unpack().dequant(),
@@ -224,7 +224,7 @@ class QConvTest(unittest.TestCase):
         )
         self.assertIs(
             ops._registry._test_get_last_op_dispatch(),
-            ops.qconv_impls.qconv2d_tensor_scaled_integer,
+            ops.qconv_impls.qconv2d_tensor_scaled,
         )
         y_ref = torch.nn.functional.conv2d(
             input_q.unpack().dequant(),


### PR DESCRIPTION
This is a follow-up to (https://github.com/nod-ai/SHARK-Platform/pull/202) which injects fp8 linear and convolution kernels in punet. 