### PR TITLE
[llama] Update kv cache to have read/write functions

### DIFF
--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -113,27 +113,16 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         # Full sequence length.
         kv_seq_len = seq_block_ids.shape[1] * self.cache.block_seq_stride
 
-        if self.cache.is_paged:
-            xk, xv = self.transact_cache_paged(
-                xk_cache_update=xk,
-                xv_cache_update=xv,
-                seq_block_ids=seq_block_ids,
-                kv_seq_len=kv_seq_len,
-                start_positions=start_positions,
-                cache_state=cache_state,
-                xk_temp=xk_temp,
-                xv_temp=xv_temp,
-            )
-        elif self.cache.is_direct:
-            xk, xv = self.transact_cache_direct(
-                xk_cache_update=xk,
-                xv_cache_update=xv,
-                start_positions=start_positions,
-                kv_seq_len=kv_seq_len,
-                cache_state=cache_state,
-            )
-        else:
-            raise NotImplementedError(f"Unsupported KV cache type: {type(self.cache)}")
+        xk, xv = self.transact_cache(
+            xk_cache_update=xk,
+            xv_cache_update=xv,
+            seq_block_ids=seq_block_ids,
+            kv_seq_len=kv_seq_len,
+            start_positions=start_positions,
+            cache_state=cache_state,
+            xk_temp=xk_temp,
+            xv_temp=xv_temp,
+        )
 
         # Expand kv heads for GQA.
         gqa_n_rep = self.head_count // self.head_count_kv
@@ -202,58 +191,20 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         h = h + attn_output
         return h
 
-    def transact_cache_direct(
-        self,
-        *,
-        cache_state: list[torch.Tensor],
-        xk_cache_update: torch.Tensor,
-        xv_cache_update: torch.Tensor,
-        kv_seq_len: int,
-        start_positions: Optional[torch.Tensor] = None,
-    ):
-        bs, batch_seq_len, _, _ = xk_cache_update.shape
-        cache_k = cache_state[self.block_index * 2]
-        cache_v = cache_state[self.block_index * 2 + 1]
-
-        if start_positions is None:
-            # Prefill. Write the entire cache.
-            cache_k[:, :batch_seq_len] = xk_cache_update
-            cache_v[:, :batch_seq_len] = xv_cache_update
-            return xk_cache_update, xv_cache_update
-        else:
-            # Decode. Write a single timestep.
-            # TODO: This needs to be reworked with index ops.
-            assert xk_cache_update.shape[1] == 1
-            assert xv_cache_update.shape[1] == 1
-            for b in range(bs):
-                # Make a tensor because indices must be all tensors, so we can avoid
-                # doing start_positions[row_index].item(), which generates a lot of SymInts.
-                row_index = torch.tensor(
-                    b, dtype=torch.int64, device=xk_cache_update.device
-                )
-                row_start_pos = start_positions[row_index]
-                cache_k.index_put_(
-                    (row_index, row_start_pos), xk_cache_update[row_index, 0]
-                )
-                cache_v.index_put_(
-                    (row_index, row_start_pos), xv_cache_update[row_index, 0]
-                )
-            return cache_k[:, :kv_seq_len], cache_v[:, :kv_seq_len]
-
-    def transact_cache_paged(
+    def transact_cache(
         self,
         *,
         xk_cache_update: torch.Tensor,
         xv_cache_update: torch.Tensor,
         cache_state: list[torch.Tensor],
         # [bs, batch_seq_len // block_seq_stride]
-        seq_block_ids: torch.Tensor,
+        seq_block_ids: Optional[torch.Tensor],
         kv_seq_len: int,
         start_positions: Optional[torch.Tensor] = None,
         xk_temp: Optional[torch.Tensor] = None,
         xv_temp: Optional[torch.Tensor] = None,
     ):
-        cache = self.cache.paged
+        cache = self.cache
         # Manage the cache.
         if start_positions is None:
             # Prefill: Write the entire cache.
@@ -264,46 +215,45 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 page_ids=seq_block_ids,
             )
             return xk_cache_update, xv_cache_update
-        else:
-            # Decode at ragged start positions.
-            # We need to initialize/read the K/V from the cache for the whole
-            # sequence. Note that at this point, it is possible to fork and
-            # use a memory efficient attention kernel that can do indirect
-            # reads, skipping this materialization. This path is taken for
-            # a decode step.
-            assert xk_temp is not None and xv_temp is not None
-            assert xk_cache_update.shape[1] == 1
-            assert xv_cache_update.shape[1] == 1
-            assert kv_seq_len == seq_block_ids.shape[1] * cache.block_seq_stride
 
-            # Write our one updated cache row into the cache.
-            cache.write_timestep(
-                cache_state,
-                cache_partitions=[
-                    xk_cache_update,
-                    xv_cache_update,
-                ],
-                transformer_block_index=self.block_index,
-                seq_positions=start_positions,
-                page_ids=seq_block_ids,
-            )
+        # Decode at ragged start positions.
+        # We need to initialize/read the K/V from the cache for the whole
+        # sequence. Note that at this point, it is possible to fork and
+        # use a memory efficient attention kernel that can do indirect
+        # reads, skipping this materialization. This path is taken for
+        # a decode step.
+        assert xk_temp is not None and xv_temp is not None
+        assert xk_cache_update.shape[1] == 1
+        assert xv_cache_update.shape[1] == 1
+        assert kv_seq_len == seq_block_ids.shape[1] * cache.block_seq_stride
 
-            # Restore from the cache.
-            cache.read(
-                cache_state,
-                read_into_partitions=[
-                    xk_temp[:, 0:kv_seq_len, ...],
-                    xv_temp[:, 0:kv_seq_len, ...],
-                ],
-                transformer_block_index=self.block_index,
-                page_ids=seq_block_ids,
-            )
+        # Write our one updated cache row into the cache.
+        cache.write_timestep(
+            cache_state,
+            cache_partitions=[
+                xk_cache_update,
+                xv_cache_update,
+            ],
+            transformer_block_index=self.block_index,
+            seq_positions=start_positions,
+            page_ids=seq_block_ids,
+        )
 
-            # For computation, we create a subview of the xk/xv tensors to have
-            # a sequence length covering the blocked size. This must include
-            # the newly added row (the caller is responsible for ensuring that
-            # every block has at least one row left). We'll compute on this
-            # ragged view and use an appropriate mask.
-            xk = xk_temp[:, 0:kv_seq_len, ...]
-            xv = xv_temp[:, 0:kv_seq_len, ...]
-            return xk, xv
+        # Restore from the cache.
+        xk, xv = cache.read(
+            cache_state,
+            read_into_partitions=[
+                xk_temp[:, 0:kv_seq_len, ...],
+                xv_temp[:, 0:kv_seq_len, ...],
+            ],
+            transformer_block_index=self.block_index,
+            page_ids=seq_block_ids,
+            seq_len=kv_seq_len,
+        )
+
+        # For computation, we create a subview of the xk/xv tensors to have
+        # a sequence length covering the blocked size. This must include
+        # the newly added row (the caller is responsible for ensuring that
+        # every block has at least one row left). We'll compute on this
+        # ragged view and use an appropriate mask.
+        return xk, xv

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -990,7 +990,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
             else:
                 # Any other collection is a indexing only dimension 0.
                 return self.shard_dim == 0
-        if len(key) < self.shard_dim:
+        if len(key) <= self.shard_dim:
             return False
         if not isinstance(key[self.shard_dim], slice):
             return True

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -8,6 +8,7 @@ import unittest
 
 import torch
 
+from sharktank.ops import replicate, unshard
 from sharktank.layers import *
 from sharktank.types import *
 
@@ -122,6 +123,111 @@ def test_direct():
 
     torch.testing.assert_close(check_concat_0, read_back[0])
     torch.testing.assert_close(check_concat_1, read_back[1])
+
+
+def test_sharded_direct():
+    bs = 4
+    seq_length = 24
+    attn_head_count = 8
+    attn_head_dim = 16
+    transformer_block_count = 4
+    shard_count = 4
+    cache = DirectKVCache(
+        block_seq_stride=4,
+        transformer_block_count=transformer_block_count,
+        attn_head_count=attn_head_count,
+        attn_head_dim=attn_head_dim,
+        seq_length=seq_length,
+        shard_count=shard_count,
+        dtype=torch.float32,
+        device=None,
+    )
+
+    allocation = cache.allocate(bs=bs)
+    # allocation = [torch.full(t.shape, 0.0, out=t) for t in allocation]
+
+    write_seq_length = seq_length - 5
+
+    # Write a prefill in:
+    write_ones = torch.full(
+        (bs, write_seq_length, attn_head_count // shard_count, attn_head_dim),
+        1.0,
+        dtype=torch.float32,
+    )
+    write_twos = torch.full(
+        (bs, write_seq_length, attn_head_count // shard_count, attn_head_dim),
+        2.0,
+        dtype=torch.float32,
+    )
+
+    write_ones = SplitPrimitiveTensor(ts=[write_ones] * shard_count, shard_dim=2)
+    write_twos = SplitPrimitiveTensor(ts=[write_twos] * shard_count, shard_dim=2)
+
+    cache.write(
+        allocation, cache_partitions=[write_ones, write_twos], transformer_block_index=1
+    )
+
+    # Check the written values have updated:
+    read_empty = [
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length,
+    )
+    torch.testing.assert_close(unshard(write_ones), unshard(read_back[0]))
+    torch.testing.assert_close(unshard(write_twos), unshard(read_back[1]))
+
+    # Write timestep
+    write_threes = torch.full(
+        (bs, 1, attn_head_count // shard_count, attn_head_dim), 3.0, dtype=torch.float32
+    )
+    write_fours = torch.full(
+        (bs, 1, attn_head_count // shard_count, attn_head_dim), 4.0, dtype=torch.float32
+    )
+
+    write_threes = SplitPrimitiveTensor(ts=[write_threes] * shard_count, shard_dim=2)
+    write_fours = SplitPrimitiveTensor(ts=[write_fours] * shard_count, shard_dim=2)
+
+    write_pos = replicate(
+        torch.full((bs,), write_seq_length, dtype=torch.int64), shard_count
+    )
+    cache.write_timestep(
+        allocation,
+        cache_partitions=[write_threes, write_fours],
+        transformer_block_index=1,
+        seq_positions=write_pos,
+    )
+
+    read_empty = [
+        torch.zeros(
+            (bs, write_seq_length + 1, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+        torch.zeros(
+            (bs, write_seq_length + 1, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length + 1,
+    )
+
+    check_concat_0 = torch.concat([unshard(write_ones), unshard(write_threes)], dim=1)
+    check_concat_1 = torch.concat([unshard(write_twos), unshard(write_fours)], dim=1)
+
+    torch.testing.assert_close(check_concat_0, unshard(read_back[0]))
+    torch.testing.assert_close(check_concat_1, unshard(read_back[1]))
 
 
 def test_paged():

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -1,0 +1,248 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.layers import *
+from sharktank.types import *
+
+
+def test_direct():
+    bs = 4
+    seq_length = 24
+    attn_head_count = 4
+    attn_head_dim = 16
+    transformer_block_count = 4
+    cache = DirectKVCache(
+        block_seq_stride=4,
+        transformer_block_count=transformer_block_count,
+        attn_head_count=attn_head_count,
+        attn_head_dim=attn_head_dim,
+        seq_length=seq_length,
+        dtype=torch.float32,
+        device=None,
+    )
+
+    allocation = cache.allocate(bs=bs)
+    allocation = [torch.full(t.shape, 0.0, out=t) for t in allocation]
+
+    write_seq_length = seq_length - 5
+
+    # Write a prefill in:
+    write_ones = torch.full(
+        (bs, write_seq_length, attn_head_count, attn_head_dim), 1.0, dtype=torch.float32
+    )
+    write_twos = torch.full(
+        (bs, write_seq_length, attn_head_count, attn_head_dim), 2.0, dtype=torch.float32
+    )
+    cache.write(
+        allocation, cache_partitions=[write_ones, write_twos], transformer_block_index=1
+    )
+
+    # Check the written values have updated:
+    read_empty = [
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length,
+    )
+    torch.testing.assert_close(write_ones, read_back[0])
+    torch.testing.assert_close(write_twos, read_back[1])
+
+    # Check the others are still zero:
+    for i in range(transformer_block_count):
+        if i == 1:
+            continue
+        read_ones = [
+            torch.zeros(
+                (bs, write_seq_length, attn_head_count, attn_head_dim),
+                dtype=torch.float32,
+            ),
+            torch.zeros(
+                (bs, write_seq_length, attn_head_count, attn_head_dim),
+                dtype=torch.float32,
+            ),
+        ]
+        read_ones = cache.read(
+            allocation,
+            read_into_partitions=read_ones,
+            transformer_block_index=i,
+            seq_len=write_seq_length,
+        )
+        torch.testing.assert_close(read_ones[0], torch.full(read_ones[0].shape, 0.0))
+        torch.testing.assert_close(read_ones[1], torch.full(read_ones[0].shape, 0.0))
+
+    # Write timestep
+    write_threes = torch.full(
+        (bs, 1, attn_head_count, attn_head_dim), 3.0, dtype=torch.float32
+    )
+    write_fours = torch.full(
+        (bs, 1, attn_head_count, attn_head_dim), 4.0, dtype=torch.float32
+    )
+    write_pos = torch.full((bs,), write_seq_length, dtype=torch.int64)
+    cache.write_timestep(
+        allocation,
+        cache_partitions=[write_threes, write_fours],
+        transformer_block_index=1,
+        seq_positions=write_pos,
+    )
+
+    read_empty = [
+        torch.zeros(
+            (bs, write_seq_length + 1, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+        torch.zeros(
+            (bs, write_seq_length + 1, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length + 1,
+    )
+
+    check_concat_0 = torch.concat([write_ones, write_threes], dim=1)
+    check_concat_1 = torch.concat([write_twos, write_fours], dim=1)
+
+    torch.testing.assert_close(check_concat_0, read_back[0])
+    torch.testing.assert_close(check_concat_1, read_back[1])
+
+
+def test_paged():
+    bs = 4
+    seq_length = 24
+    attn_head_count = 4
+    attn_head_dim = 16
+    transformer_block_count = 4
+    block_seq_stride = 4
+    cache = PagedKVCache(
+        block_seq_stride=block_seq_stride,
+        transformer_block_count=transformer_block_count,
+        attn_head_count=attn_head_count,
+        attn_head_dim=attn_head_dim,
+        dtype=torch.float32,
+        device=None,
+    )
+
+    write_seq_length = seq_length - 4
+    page_count = bs * seq_length // block_seq_stride
+    page_ids = torch.arange(page_count, dtype=torch.int64)
+    page_ids = page_ids.view(bs, seq_length // block_seq_stride)
+    write_page_ids = page_ids[:, : write_seq_length // block_seq_stride]
+
+    allocation = cache.allocate(page_count=page_count)
+    allocation = [torch.full(t.shape, 0.0, out=t) for t in allocation]
+
+    # Write a prefill in:
+    write_ones = torch.full(
+        (bs, write_seq_length, attn_head_count, attn_head_dim), 1.0, dtype=torch.float32
+    )
+    write_twos = torch.full(
+        (bs, write_seq_length, attn_head_count, attn_head_dim), 2.0, dtype=torch.float32
+    )
+
+    cache.write(
+        allocation,
+        cache_partitions=[write_ones, write_twos],
+        transformer_block_index=1,
+        page_ids=write_page_ids,
+    )
+
+    # Check the written values have updated:
+    read_empty = [
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+        torch.empty(
+            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length,
+        page_ids=write_page_ids,
+    )
+    torch.testing.assert_close(write_ones, read_back[0])
+    torch.testing.assert_close(write_twos, read_back[1])
+
+    # Check the others are still zero:
+    for i in range(transformer_block_count):
+        if i == 1:
+            continue
+        read_ones = [
+            torch.zeros(
+                (bs, write_seq_length, attn_head_count, attn_head_dim),
+                dtype=torch.float32,
+            ),
+            torch.zeros(
+                (bs, write_seq_length, attn_head_count, attn_head_dim),
+                dtype=torch.float32,
+            ),
+        ]
+        read_ones = cache.read(
+            allocation,
+            read_into_partitions=read_ones,
+            transformer_block_index=i,
+            seq_len=write_seq_length,
+            page_ids=write_page_ids,
+        )
+        torch.testing.assert_close(read_ones[0], torch.full(read_ones[0].shape, 0.0))
+        torch.testing.assert_close(read_ones[1], torch.full(read_ones[0].shape, 0.0))
+
+    # Write timestep
+    write_threes = torch.full(
+        (bs, 1, attn_head_count, attn_head_dim), 3.0, dtype=torch.float32
+    )
+    write_fours = torch.full(
+        (bs, 1, attn_head_count, attn_head_dim), 4.0, dtype=torch.float32
+    )
+    write_pos = torch.full((bs,), write_seq_length, dtype=torch.int64)
+    cache.write_timestep(
+        allocation,
+        cache_partitions=[write_threes, write_fours],
+        transformer_block_index=1,
+        seq_positions=write_pos,
+        page_ids=page_ids,
+    )
+
+    read_empty = [
+        torch.zeros(
+            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+        torch.zeros(
+            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
+            dtype=torch.float32,
+        ),
+    ]
+    read_back = cache.read(
+        allocation,
+        read_into_partitions=read_empty,
+        transformer_block_index=1,
+        seq_len=write_seq_length + 1,
+        page_ids=page_ids,
+    )
+
+    check_concat_0 = torch.concat([write_ones, write_threes], dim=1)
+    check_concat_1 = torch.concat([write_twos, write_fours], dim=1)
+
+    torch.testing.assert_close(check_concat_0, read_back[0])
+    torch.testing.assert_close(check_concat_1, read_back[1])

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -123,6 +123,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             read_into_partitions=read_into_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride
         )
         sharded_read_into_partitions = deepcopy(
             [
@@ -136,6 +137,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             read_into_partitions=sharded_read_into_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride
         )
         for unsharded, sharded in zip(
             read_into_partitions, sharded_read_into_partitions

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -123,7 +123,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             read_into_partitions=read_into_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride
+            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         sharded_read_into_partitions = deepcopy(
             [
@@ -137,7 +137,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             read_into_partitions=sharded_read_into_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride
+            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         for unsharded, sharded in zip(
             read_into_partitions, sharded_read_into_partitions


### PR DESCRIPTION
Made the interfaces of both caches line up. This allows us to interface with the caches via their utility functions instead of modifying the model behavior. Some roughness still exists in their parameters but the irrelevant details are ignored for each implementation.

Need to still add some slicing / ignoring on the page ids to make more flexible.