### PR TITLE
Ignore dir containing perplexity test from presubmit workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,4 +60,4 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/
+          pytest -n 4 sharktank/ --ignore=sharktank/tests/evaluate/


### PR DESCRIPTION
Perplexity is to run nightly but being pulled into presubmit CI. Adding ignore here to fix