### PR TITLE
Fix iree_helpers_test on Windows with callstacks (debug build).

### DIFF
--- a/shortfin/src/shortfin/support/iree_helpers_test.cc
+++ b/shortfin/src/shortfin/support/iree_helpers_test.cc
@@ -97,10 +97,9 @@ TEST(iree_error, user_message) {
         "Something went wrong",
         iree_make_status(IREE_STATUS_CANCELLED, "because I said so"));
   } catch (iree::error &e) {
-    EXPECT_THAT(
-        std::string(e.what()),
-        testing::MatchesRegex(
-            "^Something went wrong: .*: CANCELLED; because I said so$"));
+    EXPECT_THAT(std::string(e.what()),
+                testing::ContainsRegex(
+                    "^Something went wrong: .*: CANCELLED; because I said so"));
   }
 }
 
@@ -110,7 +109,7 @@ TEST(iree_error, no_user_message) {
         iree_make_status(IREE_STATUS_CANCELLED, "because I said so"));
   } catch (iree::error &e) {
     EXPECT_THAT(std::string(e.what()),
-                testing::MatchesRegex("^.*: CANCELLED; because I said so$"));
+                testing::ContainsRegex("^.*: CANCELLED; because I said so"));
   }
 }
 
@@ -129,7 +128,7 @@ TEST(iree_error, throw_if_error) {
     FAIL();
   } catch (iree::error &e) {
     EXPECT_THAT(std::string(e.what()),
-                testing::MatchesRegex("^.*: CANCELLED; because I said so$"));
+                testing::ContainsRegex("^.*: CANCELLED; because I said so"));
   }
 }
 
@@ -140,9 +139,9 @@ TEST(iree_error, throw_if_error_addl_message) {
         "oops: %d", 1);
     FAIL();
   } catch (iree::error &e) {
-    EXPECT_THAT(
-        std::string(e.what()),
-        testing::MatchesRegex("^.*: CANCELLED; because I said so; oops: 1$"));
+    EXPECT_THAT(std::string(e.what()),
+                testing::ContainsRegex("^.*: CANCELLED; because I said so;"));
+    EXPECT_THAT(std::string(e.what()), testing::ContainsRegex("oops: 1"));
   }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/nod-ai/SHARK-Platform/pull/269.

When using a debug build on Windows, status messages contain callstacks. These tests were assuming that the messages would be less helpful ;)

https://github.com/nod-ai/SHARK-Platform/actions/runs/11372553655/job/31637136796#step:9:104
```
21/32 Test #21: iree_error.user_message ......................***Failed    0.46 sec
Running main() from D:\a\SHARK-Platform\SHARK-Platform\iree\third_party\googletest\googletest\src\gtest_main.cc
Note: Google Test filter = iree_error.user_message
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from iree_error
[ RUN      ] iree_error.user_message
D:\a\SHARK-Platform\SHARK-Platform\shortfin\src\shortfin\support\iree_helpers_test.cc(103): error: Value of: std::string(e.what())
Expected: matches regular expression "^Something went wrong: .*: CANCELLED; because I said so$"
  Actual: "Something went wrong: D:\\a\\SHARK-Platform\\SHARK-Platform\\shortfin\\src\\shortfin\\support\\iree_helpers_test.cc:98: CANCELLED; because I said so; stack:\n  0x00007ff648a2273e shortfin_support_test <shortfin::iree_error_user_message_Test::TestBody+0x9e> (D:\\a\\SHARK-Platform\\SHARK-Platform\\shortfin\\src\\shortfin\\support\\iree_helpers_test.cc:96)\n  0x00007ff648a8258d shortfin_support_test <testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>+0x1d> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2628)\n  0x00007ff648a821c3 shortfin_support_test <testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>+0x73> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2671)\n  0x00007ff648a4d14c shortfin_support_test <testing::Test::Run+0xac> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2710)\n  0x00007ff648a4de04 shortfin_support_test <testing::TestInfo::Run+0x164> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2856)\n  0x00007ff648a4e881 shortfin_support_test <testing::TestSuite::Run+0x2b1> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:3034)\n  0x00007ff648a55ea6 shortfin_support_test <testing::internal::UnitTestImpl::RunAllTests+0x4b6> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:5964)\n  0x00007ff648a8264d shortfin_support_test <testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl,bool>+0x1d> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2628)\n  0x00007ff648a824d3 shortfin_support_test <testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl,bool>+0x73> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:2671)\n  0x00007ff648a4f123 shortfin_support_test <testing::UnitTest::Run+0x173> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest.cc:5543)\n  0x00007ff648ba9d53 shortfin_support_test <RUN_ALL_TESTS+0x13> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\include\\gtest\\gtest.h:2334)\n  0x00007ff648ba9d25 shortfin_support_test <main+0x35> (D:\\a\\SHARK-Platform\\SHARK-Platform\\iree\\third_party\\googletest\\googletest\\src\\gtest_main.cc:65)\n  0x00007ff648ba54f9 shortfin_support_test <invoke_main+0x39> (D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl:79)\n  0x00007ff648ba53a2 shortfin_support_test <__scrt_common_main_seh+0x132> (D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl:288)\n  0x00007ff648ba525e shortfin_support_test <__scrt_common_main+0xe> (D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl:331)\n"
```