### PR TITLE
Skip crashing shortfin python tests on Windows.

### DIFF
--- a/shortfin/tests/api/array_storage_test.py
+++ b/shortfin/tests/api/array_storage_test.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest
+import sys
 
 import shortfin as sf
 import shortfin.array as sfnp
@@ -68,6 +69,9 @@ def test_fill4(lsys, device):
     lsys.run(main())
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows fatal exception: access violation"
+)
 def test_fill_error(device):
     s = sfnp.storage.allocate_host(device, 8)
     with pytest.raises(RuntimeError):
@@ -80,6 +84,9 @@ def test_fill_error(device):
         s.fill(b"01234567")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows fatal exception: access violation"
+)
 @pytest.mark.parametrize(
     "pattern,size",
     [


### PR DESCRIPTION
Follow-up to https://github.com/nod-ai/SHARK-Platform/pull/269.

Something about this error handling is crashing the process without useful logs: https://github.com/nod-ai/SHARK-Platform/actions/runs/11373400662/job/31639876327?pr=288#step:9:131

Until we can debug that further, skip the affected tests on Windows.