### PR TITLE
[shortfin] Implements RandomGenerator and fill_randn.

### DIFF
--- a/shortfin/python/shortfin/array.py
+++ b/shortfin/python/shortfin/array.py
@@ -42,6 +42,8 @@ DType = _sfl.array.DType
 
 # Ops.
 argmax = _sfl.array.argmax
+fill_randn = _sfl.array.fill_randn
+RandomGenerator = _sfl.array.RandomGenerator
 
 __all__ = [
     # DType aliases.
@@ -78,4 +80,6 @@ __all__ = [
     "DType",
     # Ops.
     "argmax",
+    "fill_randn",
+    "RandomGenerator",
 ]


### PR DESCRIPTION
For this, I opted to only support in-place variants since in shortfin, we generally operate directly on arrays vs forcing copies or having a lot of options in constructors for managing the device assignment. Otherwise, the definition of randn matches torch.randn.

Fixes #261.