### PR TITLE
Fix `flow.tensor.transfer` placement

### DIFF
--- a/sharktank/sharktank/examples/sharding/export_ffn_net.py
+++ b/sharktank/sharktank/examples/sharding/export_ffn_net.py
@@ -50,6 +50,7 @@ class ShardedFFN(ThetaLayer):
         ffn_gate_weight = self.theta.tensor("ffn_gate", "weight")
         ffn_up_weight = self.theta.tensor("ffn_up", "weight")
         ffn_down_weight = self.theta.tensor("ffn_down", "weight")
+        x = ops.replicate(x, count=ffn_gate_weight.shard_count)
         ffn_gate = ops.elementwise(
             torch.nn.functional.silu, ops.linear(x, ffn_gate_weight)
         )
@@ -79,7 +80,7 @@ def main(raw_args=None):
     sl = 32
     hidden_dim = 128
     primary_dim = 64
-    shard_count = 8
+    shard_count = 2
     theta = create_theta(hidden_dim, primary_dim, shard_count)
 
     # Roundtrip the dataset, which anchors the tensors as parameters to be loaded

--- a/sharktank/sharktank/examples/sharding/export_ffn_net.py
+++ b/sharktank/sharktank/examples/sharding/export_ffn_net.py
@@ -80,7 +80,7 @@ def main(raw_args=None):
     sl = 32
     hidden_dim = 128
     primary_dim = 64
-    shard_count = 2
+    shard_count = 8
     theta = create_theta(hidden_dim, primary_dim, shard_count)
 
     # Roundtrip the dataset, which anchors the tensors as parameters to be loaded


### PR DESCRIPTION
We should only invoke `flow.tensor.transfer` manually or when 100% required. Invoking during each construction can result in transferring from device_0 to device_0 needlessly. It also assumes that sharding always occurs on devices 0...n when sharding + pipelining could shard across differing devices.

export_ffn_net.py shows how the replication should be defined on input and not inferred.