### PR TITLE
Make sharded in-place ops actually in-place

### DIFF
--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -207,7 +207,9 @@ class PagedKVCache(BaseKVCache):
                 )
                 for shard in page_slab.shards
             ]
-            return SplitPrimitiveTensor(ts=shards, shard_dim=4)
+            return SplitPrimitiveTensor(
+                ts=shards, shard_dim=4, insert_device_assignment=False
+            )
 
     def shard_state(
         self, state: List[torch.Tensor]
@@ -236,7 +238,9 @@ class PagedKVCache(BaseKVCache):
         shards = [
             ops.flatten(shard, start_dim=1) for shard in sharded_page_table.shards
         ]
-        flat_sharded_page_table = SplitPrimitiveTensor(ts=shards, shard_dim=1)
+        flat_sharded_page_table = SplitPrimitiveTensor(
+            ts=shards, shard_dim=1, insert_device_assignment=False
+        )
         return [flat_sharded_page_table]
 
     @property
@@ -266,7 +270,11 @@ class PagedKVCache(BaseKVCache):
                 )
                 for _ in range(self.shard_count)
             ]
-            return [SplitPrimitiveTensor(ts=shards, shard_dim=1)]
+            return [
+                SplitPrimitiveTensor(
+                    ts=shards, shard_dim=1, insert_device_assignment=False
+                )
+            ]
 
     def read(
         self,

--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -89,8 +89,12 @@ class RotaryEmbeddingLayer(BaseLayer):
             ]
             xq_shards = [xqk[0] for xqk in xqk_shards]
             xk_shards = [xqk[1] for xqk in xqk_shards]
-            xq = SplitPrimitiveTensor(ts=xq_shards, shard_dim=xq.shard_dim)
-            xk = SplitPrimitiveTensor(ts=xk_shards, shard_dim=xk.shard_dim)
+            xq = SplitPrimitiveTensor(
+                ts=xq_shards, shard_dim=xq.shard_dim, insert_device_assignment=False
+            )
+            xk = SplitPrimitiveTensor(
+                ts=xk_shards, shard_dim=xk.shard_dim, insert_device_assignment=False
+            )
             return xq, xk
         else:
             return self.forward_unsharded(
@@ -263,8 +267,12 @@ class RotaryEmbeddingLayer(BaseLayer):
             ]
             xq_shards = [xqk[0] for xqk in xqk_shards]
             xk_shards = [xqk[1] for xqk in xqk_shards]
-            xq = SplitPrimitiveTensor(ts=xq_shards, shard_dim=xq.shard_dim)
-            xk = SplitPrimitiveTensor(ts=xk_shards, shard_dim=xk.shard_dim)
+            xq = SplitPrimitiveTensor(
+                ts=xq_shards, shard_dim=xq.shard_dim, insert_device_assignment=False
+            )
+            xk = SplitPrimitiveTensor(
+                ts=xk_shards, shard_dim=xk.shard_dim, insert_device_assignment=False
+            )
             return xq, xk
         else:
             return self.apply_batched_mask_unsharded(xq=xq, xk=xk, mask=mask)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -133,11 +133,15 @@ def elementwise_unary(operator, x, *args, **kwargs):
         IsOfType(Tensor, PrimitiveTensor), IsOfType(Tensor, PrimitiveTensor, Number)
     )
 )
-def elementwise_binary(operator, x, y, *args, **kwargs):
+def elementwise_binary(
+    operator, x, y, out: Optional[Tensor | PrimitiveTensor] = None, *args, **kwargs
+):
     x = unbox_tensor(x)
     if isinstance(y, PrimitiveTensor):
         y = unbox_tensor(y)
-    return operator(x, y, *args, **kwargs)
+    if isinstance(out, PrimitiveTensor):
+        out = unbox_tensor(out)
+    return operator(x, y, *args, out=out, **kwargs)
 
 
 @elementwise.override(

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -300,11 +300,28 @@ def split_elementwise_binary(
 
 @elementwise.override(SplitPrimitiveTensor, Number)
 def elementwise_binary_split_lhs_scalar_rhs(
-    operator, x: SplitPrimitiveTensor, y: Number, *args, **kwargs
+    operator,
+    x: SplitPrimitiveTensor,
+    y: Number,
+    out: SplitPrimitiveTensor = None,
+    *args,
+    **kwargs,
 ):
-    pt_xs = [unbox_tensor(pt) for pt in x.shards]
-    partials = [operator(pt_x, y, *args, **kwargs) for pt_x in pt_xs]
-    return SplitPrimitiveTensor(shard_dim=x.shard_dim, shape=x.shape, ts=partials)
+    x_shards = [unbox_tensor(pt) for pt in x.shards]
+    out_shards = (
+        [None] * len(x.shards)
+        if out is None
+        else [unbox_tensor(shard) for shard in out.shards]
+    )
+    partials = [
+        operator(x_shard, y, out=out_shard, *args, **kwargs)
+        for x_shard, out_shard in zip(x_shards, out_shards)
+    ]
+    return SplitPrimitiveTensor(
+        shard_dim=x.shard_dim,
+        shape=x.shape,
+        ts=partials,
+    )
 
 
 @elementwise.override(SplitPrimitiveTensor, Tensor)
@@ -352,6 +369,22 @@ def elementwise_binary_split_lhs_replicated_rhs(
 
     y_sharded = reshard_like(y, like=x)
     return elementwise(operator, x, y_sharded, *args, **kwargs)
+
+
+@elementwise.override(ReplicatedTensor, Number)
+def elementwise_binary_replicated_lhs_scalar_rhs(
+    operator,
+    x: ReplicatedTensor,
+    y: Number,
+    *args,
+    **kwargs,
+):
+    shards = [
+        operator(unbox_tensor(x_shard), y, *args, **kwargs) for x_shard in x.shards
+    ]
+    return ReplicatedTensor(
+        ts=shards,
+    )
 
 
 @elementwise.override(ReplicatedTensor, UnreducedTensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -208,18 +208,18 @@ def elementwise(operator, *args, **kwargs) -> AnyTensor:
 
 @elementwise.trampoline
 def _elementwise_trampoline(d: SignatureDispatcher, operator, *args, **kwargs):
-    tensors = []
+    dispatch_args = []
     for a in args:
-        if isinstance(a, (Tensor, InferenceTensor)):
-            tensors.append(a)
+        if isinstance(a, (Tensor, InferenceTensor, Number)):
+            dispatch_args.append(a)
         else:
             break
-    for override in d.find_overrides(tensors):
+    for override in d.find_overrides(dispatch_args):
         result = override(operator, *args, **kwargs)
         if result is not NotImplemented:
             return override, result
     else:
-        d.fail(tensors)
+        d.fail(dispatch_args)
 
 
 @overridable

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -395,6 +395,11 @@ class InferenceTensor(ABC):
         # numbers on the lhs.
         return self.__add__(lhs)
 
+    def __iadd__(self, rhs):
+        from ..ops import elementwise
+
+        return elementwise(torch.add, self, rhs, out=self)
+
     def __mod__(self, rhs):
         from ..ops import elementwise
 

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import unittest
 import torch
+from torch.utils._pytree import tree_flatten
 
 from ..types import *
 
@@ -49,6 +50,14 @@ class MainRunnerTestBase(TempDirTestBase):
     def assertFileWritten(self, p: Path):
         self.assertTrue(p.exists(), msg=f"Expected file {p} was not created")
         self.assertGreater(p.stat().st_size, 0, msg=f"Expected file {p} had zero size")
+
+
+def assert_if_nan(*args, **kwargs):
+    """Assert if any torch tensors in the flattened tree have NaNs."""
+    flat_list = tree_flatten([args, kwargs])[0]
+    tensor_list = [v for v in flat_list if isinstance(v, torch.Tensor)]
+    for tensor in tensor_list:
+        assert not tensor.isnan().any(), "Encountered NaN(s) in tensor"
 
 
 @contextlib.contextmanager

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -24,6 +24,7 @@ from sharktank.utils.iree import (
     run_iree_module_function,
     prepare_iree_module_function_args,
     call_torch_module_function,
+    iree_to_torch,
 )
 import tempfile
 import torch
@@ -32,10 +33,6 @@ from iree.turbine.aot import FxProgramsBuilder, export
 import iree.runtime
 import numpy as np
 import os
-
-
-def iree_to_torch(*tensors: iree.runtime.DeviceArray) -> List[torch.Tensor]:
-    return [torch.tensor(tensor.to_host()) for tensor in tensors]
 
 
 @pytest.mark.usefixtures("caching", "path_prefix")

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -266,7 +266,7 @@ class ShardedLlamaTest(unittest.TestCase):
             sharded_fxb = FxProgramsBuilder(sharded_model)
 
             @sharded_fxb.export_program(
-                name="prefill", args=tuple(), kwargs=sharded_prefill_args
+                name="prefill", args=tuple(), kwargs=sharded_prefill_args, strict=False
             )
             def _(model, *args, **kwargs) -> torch.Tensor:
                 return model.prefill(*args, **kwargs)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -6,13 +6,23 @@
 
 import unittest
 from parameterized import parameterized
-
+import tempfile
+import pytest
+from copy import deepcopy
 import torch
 
 from sharktank import ops
 from sharktank.types import *
 from sharktank.types import sharding
 from sharktank.layers import Conv2DLayer
+from sharktank.utils.iree import (
+    get_iree_devices,
+    load_iree_module,
+    run_iree_module_function,
+    prepare_iree_module_function_args,
+    iree_to_torch,
+)
+from iree.turbine.aot import FxProgramsBuilder, export
 
 
 class AllGatherTest(unittest.TestCase):
@@ -233,6 +243,7 @@ class ConvTest(unittest.TestCase):
         assert ops.equal(expected_result, actual_result)
 
 
+@pytest.mark.usefixtures("path_prefix")
 class ElementwiseTest(unittest.TestCase):
     def testRhsAndLhsShardedAdd(self):
         a = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -311,6 +322,83 @@ class ElementwiseTest(unittest.TestCase):
         assert sharded_result.shard_count == sharded_a.shard_count
         assert sharded_result.shard_dim == sharded_a.shard_dim
         actual_result = ops.reshard_like(sharded_result, expected_result)
+        torch.testing.assert_close(actual_result, expected_result)
+
+    def testInPlaceAddWithIree(self):
+        if self.path_prefix is not None:
+            self.runTestInPlaceAddWithIree(
+                path_prefix=self.path_prefix, dump_enabled=True
+            )
+        else:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.runTestInPlaceAddWithIree(
+                    path_prefix=f"{temp_dir}/", dump_enabled=False
+                )
+
+    def runTestInPlaceAddWithIree(self, path_prefix: str, dump_enabled: bool):
+        dtype = torch.float32
+
+        class Module(torch.nn.Module):
+            def main(self, tensor: torch.Tensor) -> torch.Tensor:
+                tensor += 1
+                # TODO: figure out why when not returning anything the export fails.
+                return torch.empty([1], dtype=dtype)
+
+        tensor = torch.tensor([1, 2, 3], dtype=dtype)
+        expected_result = torch.tensor([2, 3, 4], dtype=dtype)
+
+        module = Module()
+        fxb = FxProgramsBuilder(module)
+
+        @fxb.export_program(
+            args=(tensor,),
+            name="main",
+            strict=False,
+        )
+        def _(model, *args, **kwargs):
+            return model.main(*args, **kwargs)
+
+        if dump_enabled:
+            for program_name, ep in fxb.programs.items():
+                with open(
+                    f"{path_prefix}{program_name}.torch.fx.txt",
+                    "w",
+                ) as f:
+                    print(str(ep), file=f)
+
+        output = export(fxb)
+        if dump_enabled:
+            output.save_mlir(f"{path_prefix}program.mlir")
+
+        iree_module_path = f"{path_prefix}program.vmfb"
+        output.session.set_flags("--iree-hal-target-device=llvm-cpu")
+        output.compile(
+            save_to=iree_module_path,
+            target_backends=None,
+        )
+
+        iree_driver = "local-task"
+        iree_devices = get_iree_devices(
+            driver=iree_driver,
+            device_count=1,
+        )
+        iree_module, vm_context, vm_instance = load_iree_module(
+            module_path=iree_module_path,
+            devices=iree_devices,
+        )
+        iree_args = prepare_iree_module_function_args(
+            args=[deepcopy(tensor)], devices=iree_devices
+        )
+        run_iree_module_function(
+            args=iree_args,
+            function_name="main",
+            module=iree_module,
+            vm_context=vm_context,
+            driver=iree_driver,
+            trace_path_prefix=path_prefix if dump_enabled else None,
+            # trace_path_prefix=None
+        )
+        actual_result = iree_to_torch(*iree_args)[0]
         torch.testing.assert_close(actual_result, expected_result)
 
 


### PR DESCRIPTION
We would insert transfers to devices on each sharded tensor
construction, which is wrong for results of in-place ops.
    
This fixes the issue for most ops except some cases of elementwise ops.
It relies on the change https://github.com/iree-org/iree-turbine/pull/239
that harmonizes the behavior of tensor transfers between eager and compiled
execution.

This fixes the cache updates for the toy-sized sharded Llama model.
Minus the smallish numerical inaccuracies, which are probably to be expected.

Added atentry/atexit hooks to the signature dispatcher.
I used them during debugging. They should be useful in the future as well.