### PR TITLE
Harmonize ops/tests with non-in-place transfer even for eager

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1064,7 +1064,9 @@ class ReplicatedTensor(ShardedTensor):
         """
         if isinstance(ts, torch.Tensor):
             assert shard_count is not None
-            ts = [ts] * shard_count
+            from ..ops import transfer_to_logical_device
+
+            ts = [transfer_to_logical_device(ts, i) for i in range(shard_count)]
             shard_count = None
 
         assert shard_count is None

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -786,9 +786,9 @@ class ReplicateTest(unittest.TestCase):
         expected_result = ReplicatedTensor(ts=tensor, shard_count=shard_count)
         assert expected_result.is_deep_equal(actual_result)
 
-        # Test not a copy.
+        # Test that is a copy.
         tensor[...] = torch.rand_like(tensor)
-        assert all(ops.equal(tensor, shard) for shard in actual_result.shards)
+        assert all(not ops.equal(tensor, shard) for shard in actual_result.shards)
 
 
 class ReshapeTest(unittest.TestCase):
@@ -905,10 +905,10 @@ class ReshardSplitTest(unittest.TestCase):
         )
         assert expected_result.is_deep_equal(actual_result)
 
-        # Test not a copy.
+        # Test that is a copy.
         tensor[...] = torch.rand_like(tensor)
         result_split2 = ops.reshard_split(tensor, dim=shard_dim, count=shard_count)
-        assert ops.equal(actual_result, result_split2)
+        assert not ops.equal(actual_result, result_split2)
 
     def testReshardSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)


### PR DESCRIPTION
This makes the code compatible with the change
https://github.com/iree-org/iree-turbine/pull/239

Avoid transfers in all gather/reduce for same shard/device tensors. This removes one unnecessary transfer per device.