### PR TITLE
Make toy-sized Llama export non-strict

### DIFF
--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -289,7 +289,7 @@ class ShardedLlamaTest(unittest.TestCase):
             sharded_fxb = FxProgramsBuilder(sharded_model)
 
             @sharded_fxb.export_program(
-                name="prefill", args=tuple(), kwargs=sharded_prefill_args
+                name="prefill", args=tuple(), kwargs=sharded_prefill_args, strict=False
             )
             def _(model, *args, **kwargs) -> torch.Tensor:
                 return model.prefill(*args, **kwargs)


### PR DESCRIPTION
When strict it fails due to having the UnreducedTensor not being registered in torch.