### PR TITLE
Update Llama Benchmarking CI machine, test paths, and schedule

### DIFF
--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -2,9 +2,10 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
-    # Weekdays at 9:00 AM UTC = 2:00 AM PST.
-    - cron: "0 9 * * 1-5"
+    # Weekdays at 5:00 AM UTC = 10:00 PM PST.
+    - cron: "0 5 * * 1-5"
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -21,7 +22,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300
+    runs-on: llama-mi300x-1
     defaults:
       run:
         shell: bash

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -183,7 +183,7 @@ def main():
             args=(tokens, seq_lens, seq_block_ids, cache),
             dynamic_shapes=dynamic_shapes,
             strict=args.strict,
-            argument_device_affinities=arg_affinities,
+            arg_device=arg_affinities,
         )
         def _(model, tokens, seq_lens, seq_block_ids, cs):
             cache_tensors = cs
@@ -253,7 +253,7 @@ def main():
             ),
             dynamic_shapes=dynamic_shapes,
             strict=args.strict,
-            argument_device_affinities=arg_affinities,
+            arg_device=arg_affinities,
         )
         def _(
             model,

--- a/sharktank/tests/models/llama/benchmark_amdgpu_tests.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_tests.py
@@ -251,7 +251,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
     def setUp(self):
         super().setUp()
         # TODO: add numpy files to Azure and download from it
-        artifacts_dir = Path("/data/extra/models/llama3.1_8B")
+        artifacts_dir = Path("/data/llama-3.1/8b")
         self.irpa_path = artifacts_dir / "llama8b_f16.irpa"
         self.irpa_path_fp8 = artifacts_dir / "llama8b_fp8.irpa"
         self.tensor_parallelism_size = None
@@ -473,7 +473,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     def setUp(self):
         super().setUp()
         # TODO: add numpy files to Azure and download from it
-        artifacts_dir = Path("/data/extra/models/llama3.1_70B")
+        artifacts_dir = Path("/data/llama-3.1/70b")
         self.irpa_path = artifacts_dir / "llama70b_f16.irpa"
         self.irpa_path_fp8 = artifacts_dir / "llama70b_fp8.irpa"
         self.tensor_parallelism_size = 1
@@ -696,7 +696,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
     def setUp(self):
         super().setUp()
         # TODO: add numpy files to Azure and download from it
-        artifacts_dir = Path("/data/extra/models/llama3.1_405B")
+        artifacts_dir = Path("/data/llama-3.1/405b")
         self.irpa_path = artifacts_dir / "llama405b_f16.irpa"
         self.irpa_path_fp8 = artifacts_dir / "llama405b_fp8.irpa"
         self.tensor_parallelism_size = 8

--- a/sharktank/tests/models/llama/benchmark_amdgpu_tests.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_tests.py
@@ -254,7 +254,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
         artifacts_dir = Path("/data/llama-3.1/8b")
         self.irpa_path = artifacts_dir / "llama8b_f16.irpa"
         self.irpa_path_fp8 = artifacts_dir / "llama8b_fp8.irpa"
-        self.tensor_parallelism_size = None
+        self.tensor_parallelism_size = 1
         self.dir_path_8b = self.dir_path / "llama-8b"
         self.temp_dir_8b = Path(self.dir_path_8b)
         self.temp_dir_8b.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR changes the benchmarking CI machine from the `A30F` machine to the `SharkMi300X` machine for Llama 8b, 70b, and 405b decomposed and non-decomposed sdpa. It also changes the schedule of the CI run from 2:00 AM PT to 10:00 PM PT and fixes the `argument_device_affinities` keyword to `arg_device` instead.