### PR TITLE
Add reporting for llama testing and improve error handling

### DIFF
--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -8,6 +8,7 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     # Weekdays at 5:00 AM UTC = 10:00 PM PST.
     - cron: "0 5 * * 1-5"

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
-          publish_dir: ./report.html
+          publish_dir: ./llama-report.html
 
       - name: Upload llama executable files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -8,7 +8,6 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Weekdays at 5:00 AM UTC = 10:00 PM PST.
     - cron: "0 5 * * 1-5"
@@ -76,7 +75,13 @@ jobs:
             "numpy<2.0"
 
       - name: Run llama test
-        run: pytest sharktank/tests/models/llama/benchmark_amdgpu_test.py -v -s --longrun --iree-hip-target=gfx942
+        run: pytest sharktank/tests/models/llama/benchmark_amdgpu_test.py -v -s --longrun --iree-hip-target=gfx942 --html=report.html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
+          publish_dir: ./report.html
 
       - name: Upload llama executable files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    # Weekdays at 5:00 AM UTC = 10:00 PM PST.
+    # Weekdays at 5:00 AM UTC = 10:00 PM PST. test
     - cron: "0 5 * * 1-5"
 
 concurrency:

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -76,7 +76,7 @@ jobs:
             "numpy<2.0"
 
       - name: Run llama test
-        run: pytest sharktank/tests/models/llama/benchmark_amdgpu_test.py -v -s --longrun --iree-hip-target=gfx942 --html=report.html
+        run: pytest sharktank/tests/models/llama/benchmark_amdgpu_test.py -v -s --longrun --iree-hip-target=gfx942 --html=out/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
-          publish_dir: ./
+          publish_dir: ./out
 
       - name: Upload llama executable files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    # Weekdays at 5:00 AM UTC = 10:00 PM PST. test
+    # Weekdays at 5:00 AM UTC = 10:00 PM PST.
     - cron: "0 5 * * 1-5"
 
 concurrency:

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -66,7 +66,6 @@ jobs:
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
-          pip install pytest-html
 
           # Try with the latest nightly releases, not what iree-turbine pins.
           # We could also pin to a known working or stable version.

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -8,7 +8,6 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Weekdays at 5:00 AM UTC = 10:00 PM PST.
     - cron: "0 5 * * 1-5"

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -66,6 +66,7 @@ jobs:
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
+          pip install pytest-html
 
           # Try with the latest nightly releases, not what iree-turbine pins.
           # We could also pin to a known working or stable version.

--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
-          publish_dir: ./llama-report.html
+          publish_dir: ./
 
       - name: Upload llama executable files
         uses: actions/upload-artifact@v4

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from pytest import FixtureRequest
 from typing import Optional, Any
-from pytest_html import extras, hooks
+from pytest_html import extras, plugin
 
 
 # Tests under each top-level directory will get a mark.
@@ -258,15 +258,14 @@ def get_iree_flags(request: FixtureRequest):
         request, "--iree-hal-target-backends", "iree_hal_target_backends"
     )
 
-# Hook to add extra columns or modify the table row in the pytest-html report
 def pytest_html_results_table_header(cells):
-    cells.insert(2, hooks.html.Cell("XFail Reason"))
+    cells.insert(2, plugin.html.th("XFail Reason"))
 
 def pytest_html_results_table_row(report, cells):
     if hasattr(report, "wasxfail"):
-        cells.insert(2, hooks.html.Cell(report.wasxfail))
+        cells.insert(2, plugin.html.td(report.wasxfail))
     else:
-        cells.insert(2, hooks.html.Cell(""))
+        cells.insert(2, plugin.html.td(""))
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from pytest import FixtureRequest
 from typing import Optional, Any
+from pytest_html import extras, hooks
 
 
 # Tests under each top-level directory will get a mark.
@@ -259,15 +260,13 @@ def get_iree_flags(request: FixtureRequest):
 
 # Hook to add extra columns or modify the table row in the pytest-html report
 def pytest_html_results_table_header(cells):
-    cells.insert(2, "XFail Reason")
-
+    cells.insert(2, hooks.html.Cell("XFail Reason"))
 
 def pytest_html_results_table_row(report, cells):
     if hasattr(report, "wasxfail"):
-        cells.insert(2, report.wasxfail)
+        cells.insert(2, hooks.html.Cell(report.wasxfail))
     else:
-        cells.insert(2, "")
-
+        cells.insert(2, hooks.html.Cell(""))
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
@@ -275,4 +274,4 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
 
     if report.when == "call" and hasattr(report, "wasxfail"):
-        report.wasxfail = report.wasxfail
+        report.wasxfail = getattr(report, "wasxfail", "")

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 from pytest import FixtureRequest
 from typing import Optional, Any
-from pytest_html import extras, plugin
 
 
 # Tests under each top-level directory will get a mark.
@@ -259,18 +258,18 @@ def get_iree_flags(request: FixtureRequest):
     )
 
 def pytest_html_results_table_header(cells):
-    cells.insert(2, plugin.html.th("XFail Reason"))
+    cells.insert(2, "<th>XFail Reason</th>")
 
 def pytest_html_results_table_row(report, cells):
     if hasattr(report, "wasxfail"):
-        cells.insert(2, plugin.html.td(report.wasxfail))
+        cells.insert(2, f"<td>{report.wasxfail}</td>")
     else:
-        cells.insert(2, plugin.html.td(""))
+        cells.insert(2, f"<td></td>")
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
 
-    if report.when == "call" and hasattr(report, "wasxfail"):
-        report.wasxfail = getattr(report, "wasxfail", "")
+    if report.when == "call" and hasattr(item, "wasxfail"):
+        report.wasxfail = item.wasxfail

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -257,14 +257,17 @@ def get_iree_flags(request: FixtureRequest):
         request, "--iree-hal-target-backends", "iree_hal_target_backends"
     )
 
+
 def pytest_html_results_table_header(cells):
     cells.insert(2, "<th>XFail Reason</th>")
+
 
 def pytest_html_results_table_row(report, cells):
     if hasattr(report, "wasxfail"):
         cells.insert(2, f"<td>{report.wasxfail}</td>")
     else:
         cells.insert(2, f"<td></td>")
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -256,3 +256,22 @@ def get_iree_flags(request: FixtureRequest):
     model_path["iree_hal_target_backends"] = set_fixture_from_cli_option(
         request, "--iree-hal-target-backends", "iree_hal_target_backends"
     )
+
+# Hook to add extra columns or modify the table row in the pytest-html report
+def pytest_html_results_table_header(cells):
+    cells.insert(2, 'XFail Reason')
+
+
+def pytest_html_results_table_row(report, cells):
+    if hasattr(report, 'wasxfail'):
+        cells.insert(2, report.wasxfail)
+    else:
+        cells.insert(2, '')
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when == "call" and hasattr(report, 'wasxfail'):
+        report.wasxfail = report.wasxfail

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -259,19 +259,20 @@ def get_iree_flags(request: FixtureRequest):
 
 # Hook to add extra columns or modify the table row in the pytest-html report
 def pytest_html_results_table_header(cells):
-    cells.insert(2, 'XFail Reason')
+    cells.insert(2, "XFail Reason")
 
 
 def pytest_html_results_table_row(report, cells):
-    if hasattr(report, 'wasxfail'):
+    if hasattr(report, "wasxfail"):
         cells.insert(2, report.wasxfail)
     else:
-        cells.insert(2, '')
+        cells.insert(2, "")
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
 
-    if report.when == "call" and hasattr(report, 'wasxfail'):
+    if report.when == "call" and hasattr(report, "wasxfail"):
         report.wasxfail = report.wasxfail

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -258,6 +258,7 @@ def get_iree_flags(request: FixtureRequest):
     )
 
 
+# The following three functions allow us to add a "XFail Reason" column to the html reports for each test
 def pytest_html_results_table_header(cells):
     cells.insert(2, "<th>XFail Reason</th>")
 

--- a/sharktank/requirements-tests.txt
+++ b/sharktank/requirements-tests.txt
@@ -1,3 +1,4 @@
 datasets==3.0.0
 parameterized
 pytest==8.0.0
+pytest-html

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -195,6 +195,8 @@ class ExportArtifacts:
         hal_dump_path,
         cwd
     ):
+        compile_flags = ["--iree-hip-target=" + self.iree_hip_target]
+        compile_flags += [f"--iree-hal-dump-executable-files-to={hal_dump_path}/files"]
         cmd = self.get_compile_cmd(
             output_mlir_path=mlir_path,
             output_vmfb_path=vmfb_path,
@@ -240,7 +242,7 @@ class ExportArtifacts:
         proc = subprocess.run(cmd, shell=True, stdout=sys.stdout, cwd=cwd)
         return_code = proc.returncode
         if return_code != 0:
-            raise IreeBenchmarkException(proc, cwd, cmd)
+            raise IreeBenchmarkException(proc, cwd)
 
     def create_file(self, *, suffix, prefix):
         file_path = Path(prefix).with_suffix(suffix)

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -196,6 +196,7 @@ class ExportArtifacts:
         cwd
     ):
         compile_flags = ["--iree-hip-target=" + self.iree_hip_target]
+        compile_flags += ["--iree-hal-target-backends=rocm"]
         compile_flags += [f"--iree-hal-dump-executable-files-to={hal_dump_path}/files"]
         cmd = self.get_compile_cmd(
             output_mlir_path=mlir_path,

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -23,8 +23,10 @@ logger.root.handlers[0].setFormatter(
     logging.Formatter(fmt="\n%(levelname)s:%(name)-8s %(message)s")
 )
 
+
 class ExportMlirException(Exception):
     """SHARK-Platform export MLIR exception that preserves the command line and error output."""
+
     def __init__(self, process: subprocess.CompletedProcess, cwd: str):
         try:
             errs = process.stderr.decode("utf-8")
@@ -38,8 +40,10 @@ class ExportMlirException(Exception):
             f"  cd {cwd} && {process.args}\n\n"
         )
 
+
 class IreeCompileException(Exception):
     """Compiler exception that preserves the command line and error output."""
+
     def __init__(self, process: subprocess.CompletedProcess, cwd: str):
         try:
             errs = process.stderr.decode("utf-8")
@@ -53,11 +57,11 @@ class IreeCompileException(Exception):
             f"  cd {cwd} && {process.args}\n\n"
         )
 
+
 class IreeBenchmarkException(Exception):
     """Runtime exception that preserves the command line and error output."""
-    def __init__(
-        self, process: subprocess.CompletedProcess, cwd: str
-    ):
+
+    def __init__(self, process: subprocess.CompletedProcess, cwd: str):
         # iree-run-module sends output to both stdout and stderr
         try:
             errs = process.stderr.decode("utf-8")
@@ -187,14 +191,7 @@ class ExportArtifacts:
         return proc.returncode
 
     @timeit
-    def compile_to_vmfb(
-        self,
-        *,
-        mlir_path,
-        vmfb_path,
-        hal_dump_path,
-        cwd
-    ):
+    def compile_to_vmfb(self, *, mlir_path, vmfb_path, hal_dump_path, cwd):
         compile_flags = ["--iree-hip-target=" + self.iree_hip_target]
         compile_flags += ["--iree-hal-target-backends=rocm"]
         compile_flags += [f"--iree-hal-dump-executable-files-to={hal_dump_path}/files"]
@@ -249,7 +246,7 @@ class ExportArtifacts:
         file_path = Path(prefix).with_suffix(suffix)
         f = open(file_path, "w")
         return file_path
-    
+
     def get_compile_cmd(
         self, *, output_mlir_path: str, output_vmfb_path: str, args: [str]
     ):

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -97,15 +97,6 @@ class ExportArtifacts:
         self.iree_hal_target_backends = iree_hal_target_backends
         self.attention_kernel = attention_kernel
         self.tensor_parallelism_size = tensor_parallelism_size
-    
-    def get_compile_cmd(
-        self, *, output_mlir_path: str, output_vmfb_path: str, args: [str]
-    ):
-        compile_args = ["iree-compile", output_mlir_path]
-        compile_args += args
-        compile_args += ["-o", output_vmfb_path]
-        cmd = subprocess.list2cmdline(compile_args)
-        return cmd
 
     def timeit(func):
         def wrapper(*args, **kwargs):
@@ -255,6 +246,15 @@ class ExportArtifacts:
         file_path = Path(prefix).with_suffix(suffix)
         f = open(file_path, "w")
         return file_path
+    
+    def get_compile_cmd(
+        self, *, output_mlir_path: str, output_vmfb_path: str, args: [str]
+    ):
+        compile_args = ["iree-compile", output_mlir_path]
+        compile_args += args
+        compile_args += ["-o", output_vmfb_path]
+        cmd = subprocess.list2cmdline(compile_args)
+        return cmd
 
     def get_artifacts(self):
 

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -353,7 +353,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+        reason="IREE Invocation (OOM)", strict=True, raises=IreeBenchmarkException
     )
     def testBenchmark70B_f16_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_decomposed"

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -156,7 +156,9 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark8B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "f16_torch"
         output_mlir = self.llama8b_f16_artifacts.create_file(
@@ -207,7 +209,9 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
+    @pytest.mark.xfail(
+        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+    )
     def testBenchmark8B_fp8_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -249,7 +253,9 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark8B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -346,7 +352,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
+    @pytest.mark.xfail(
+        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+    )
     def testBenchmark70B_f16_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -388,7 +396,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark70B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -430,7 +440,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
+    @pytest.mark.xfail(
+        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+    )
     def testBenchmark70B_fp8_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -472,7 +484,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark70B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -611,7 +625,9 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark405B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "f16_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -653,7 +669,9 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
+    @pytest.mark.xfail(
+        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+    )
     def testBenchmark405B_fp8_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -695,7 +713,9 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
+    @pytest.mark.xfail(
+        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+    )
     def testBenchmark405B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -158,7 +158,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Compile Error", strict=True, raises=IreeCompileException
     )
     def testBenchmark8B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "f16_torch"
@@ -212,7 +212,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark8B_fp8_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_decomposed"
@@ -256,7 +256,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark8B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_torch_sdpa"
@@ -355,7 +355,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="IREE Invocation (OOM)", strict=True, raises=IreeBenchmarkException
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark70B_f16_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_decomposed"
@@ -399,7 +399,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark70B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_torch_sdpa"
@@ -443,7 +443,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark70B_fp8_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_decomposed"
@@ -487,7 +487,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark70B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_torch_sdpa"
@@ -585,7 +585,9 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="Export", strict=True, raises=ExportMlirException)
+    @pytest.mark.xfail(
+        reason="Test not yet implemented", strict=True, raises=AttributeError
+    )
     def testBenchmark405B_f16_Decomposed(self):
         output_file_name = self.dir_path_405b / "f16_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -628,7 +630,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark405B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "f16_torch_sdpa"
@@ -672,7 +674,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (File Not Found)", strict=True, raises=ExportMlirException
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark405B_fp8_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_decomposed"
@@ -716,7 +718,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
     @longrun
     @is_mi300x
     @pytest.mark.xfail(
-        reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError
+        reason="Test not yet implemented", strict=True, raises=AttributeError
     )
     def testBenchmark405B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_torch_sdpa"

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -136,6 +136,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             mlir_path=str(output_mlir),
             vmfb_path=output_vmfb,
             hal_dump_path=output_file_name,
+            cwd=self.repo_root,
         )
         # benchmark prefill
         self.llama8b_f16_artifacts.iree_benchmark_vmfb(
@@ -189,6 +190,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             mlir_path=str(output_mlir),
             vmfb_path=output_vmfb,
             hal_dump_path=output_file_name,
+            cwd=self.repo_root,
         )
         # benchmark prefill
         self.llama8b_f16_artifacts.iree_benchmark_vmfb(

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -13,7 +13,7 @@ import pytest
 import subprocess
 from pathlib import Path
 from typing import List
-from sharktank.utils.export_artifacts import ExportArtifacts
+from sharktank.utils.export_artifacts import ExportArtifacts, ExportMlirException, IreeBenchmarkException, IreeCompileException
 
 longrun = pytest.mark.skipif("not config.getoption('longrun')")
 is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -13,7 +13,12 @@ import pytest
 import subprocess
 from pathlib import Path
 from typing import List
-from sharktank.utils.export_artifacts import ExportArtifacts, ExportMlirException, IreeBenchmarkException, IreeCompileException
+from sharktank.utils.export_artifacts import (
+    ExportArtifacts,
+    ExportMlirException,
+    IreeBenchmarkException,
+    IreeCompileException,
+)
 
 longrun = pytest.mark.skipif("not config.getoption('longrun')")
 is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
@@ -157,9 +162,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(
-        reason="Compile Error", strict=True, raises=IreeCompileException
-    )
+    @pytest.mark.xfail(reason="Compile Error", strict=True, raises=IreeCompileException)
     def testBenchmark8B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "f16_torch"
         output_mlir = self.llama8b_f16_artifacts.create_file(

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -156,7 +156,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark8B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "f16_torch"
         output_mlir = self.llama8b_f16_artifacts.create_file(
@@ -207,7 +207,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="8B fp8 irpa path not stored yet", strict=True)
+    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
     def testBenchmark8B_fp8_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -249,7 +249,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark8B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -346,7 +346,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="70b f16 irpa path not stored yet", strict=True)
+    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
     def testBenchmark70B_f16_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -388,7 +388,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark70B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "f16_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -430,7 +430,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="70B fp8 irpa path not stored yet", strict=True)
+    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
     def testBenchmark70B_fp8_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -472,7 +472,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark70B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_70b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -569,7 +569,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="405B f16 irpa path not stored yet", strict=True)
+    @pytest.mark.xfail(reason="Export", strict=True, raises=ExportMlirException)
     def testBenchmark405B_f16_Decomposed(self):
         output_file_name = self.dir_path_405b / "f16_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -611,7 +611,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark405B_f16_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "f16_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -653,7 +653,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="405B fp8 irpa path not stored yet", strict=True)
+    @pytest.mark.xfail(reason="Export (File Not Found)", strict=True, raises=ExportMlirException)
     def testBenchmark405B_fp8_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_decomposed"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)
@@ -695,7 +695,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
 
     @longrun
     @is_mi300x
-    @pytest.mark.xfail(reason="torch_sdpa not yet plumbed through", strict=True)
+    @pytest.mark.xfail(reason="Export (torch_sdpa)", strict=True, raises=NotImplementedError)
     def testBenchmark405B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_405b / "fp8_torch_sdpa"
         output_mlir = self.create_file(suffix=".mlir", prefix=output_file_name)


### PR DESCRIPTION
This commit generates reports for the llama testing. Every time it runs it in CI, it will deploy to github pages (https://nod-ai.github.io/SHARK-Platform). @aviator19941 is working on getting the rest of the tests properly implemented. Only the llama8b fp16 tests are working as intended at the moment.