### PR TITLE
Add device affinity to sharded tensors

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -169,6 +169,9 @@ def main():
         # We need to offset the indices for the cache
         arg_affinities = {key + 3: arg_affinities[key] for key in arg_affinities}
 
+        for i in range(3):
+            arg_affinities[i] = DeviceAffinity("0")
+
         dynamic_shapes = {
             "tokens": {1: sl_dim},
             "seq_lens": {},
@@ -231,6 +234,10 @@ def main():
 
         # We need to offset the indices for the cache
         arg_affinities = {key + 4: arg_affinities[key] for key in arg_affinities}
+
+        # Inputs have default affinity 0
+        for i in range(4):
+            arg_affinities[i] = DeviceAffinity("0")
 
         dynamic_shapes = {
             "tokens": {},

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -29,6 +29,7 @@ from torch.utils._pytree import register_pytree_node, SequenceKey
 import torch.utils._pytree
 from ..utils.math import ceildiv
 from iree.turbine.aot import (
+    DeviceTensorTrait,
     ExternalTensorTrait,
 )
 from ..utils import tree as tree_utils
@@ -838,6 +839,8 @@ class ShardedTensorBase(ShardedTensor):
             try:
                 t = raw_tensors[t_name]
                 ts.append(t)
+                # TODO: this should be changed to tracked device affinity
+                DeviceTensorTrait(f"__device_{i}").set(t)
             except KeyError as e:
                 raise IOError(
                     f"Missing component tensor '{t_name}' in {raw_tensors.keys()}"
@@ -1135,10 +1138,21 @@ class ReplicatedTensor(ShardedTensor):
     ) -> "InferenceTensor":
         shard_count = int(extra_properties["shard_count"])
         try:
-            ts = raw_tensors[""]
+            # We have to do this to avoid exporting as part of the `mlir` blob:
+            t = raw_tensors[""]
+            ts = [raw_tensors[""]]
+            name = t.name
+            for i in range(1, shard_count):
+                nt = deepcopy(t)
+                ts.append(nt)
+
+            # TODO This should be changed to assigned affinities
+            for i in range(shard_count):
+                DeviceTensorTrait(f"__device_{i}").set(ts[i])
+
         except KeyError as e:
             raise IOError(f"Missing component tensor '' in {raw_tensors.keys()}") from e
-        return cls(name=name, ts=ts, shard_count=shard_count)
+        return cls(name=name, ts=ts)
 
     def __getitem__(self, key):
         if isinstance(key, ReplicatedTensor):

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -840,7 +840,7 @@ class ShardedTensorBase(ShardedTensor):
                 t = raw_tensors[t_name]
                 ts.append(t)
                 # TODO: this should be changed to tracked device affinity
-                DeviceTensorTrait(f"__device_{i}").set(t)
+                DeviceTensorTrait(i).set(t)
             except KeyError as e:
                 raise IOError(
                     f"Missing component tensor '{t_name}' in {raw_tensors.keys()}"
@@ -1148,7 +1148,7 @@ class ReplicatedTensor(ShardedTensor):
 
             # TODO This should be changed to assigned affinities
             for i in range(shard_count):
-                DeviceTensorTrait(f"__device_{i}").set(ts[i])
+                DeviceTensorTrait(i).set(ts[i])
 
         except KeyError as e:
             raise IOError(f"Missing component tensor '' in {raw_tensors.keys()}") from e

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1141,7 +1141,6 @@ class ReplicatedTensor(ShardedTensor):
             # We have to do this to avoid exporting as part of the `mlir` blob:
             t = raw_tensors[""]
             ts = [raw_tensors[""]]
-            name = t.name
             for i in range(1, shard_count):
                 nt = deepcopy(t)
                 ts.append(nt)

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -62,10 +62,8 @@ class PlanarQuantizedTensorTest(unittest.TestCase):
 
 class ShardedTensorTest(unittest.TestCase):
     def testReplicatedTensorSaveLoad(self):
-        tensor = torch.rand([2, 3, 4], dtype=torch.float32)
-        replicated_tensor = ReplicatedTensor(
-            ts=tensor, shard_count=3, name="the_tensor"
-        )
+        tensor = [torch.rand([2, 3, 4], dtype=torch.float32)] * 3
+        replicated_tensor = ReplicatedTensor(ts=tensor, name="the_tensor")
         theta = Theta([replicated_tensor])
         dataset = Dataset({}, theta)
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
This adds some default device affinities to loaded sharded tensors. This still needs to be updated for a configurable allocation but enables our current models to run on per-tensor parallelism.