### PR TITLE
Fix different --bs=1 behavior

### DIFF
--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -15,7 +15,7 @@ When in question, we draw from the vocabulary and normalization they have done
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Literal
 import torch
 
 __all__ = ["LlamaHParams", "LlamaModelConfig"]
@@ -124,7 +124,7 @@ class LlamaModelConfig:
     block_seq_stride: int = 16
 
     # Either "paged" or "direct".
-    kv_cache_type: str = "paged"
+    kv_cache_type: Literal["paged", "direct"] = "paged"
 
     # The device on which to place intermediate state.
     device: Optional[torch.device] = None


### PR DESCRIPTION
https://xilinx.slack.com/archives/C079V23F7CP/p1729805729161599

A lot of us newcomers are running into issues where we expect a bs=1 vmfb to be a drop in replacement for a bs=4 vmfb, but it's not.

I think we should do a different cmdline arg for serving local.