### PR TITLE
Remove llama benchmarking CI on pull_request

### DIFF
--- a/.github/workflows/ci-llama.yaml
+++ b/.github/workflows/ci-llama.yaml
@@ -2,7 +2,6 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Weekdays at 5:00 AM UTC = 10:00 PM PST.
     - cron: "0 5 * * 1-5"


### PR DESCRIPTION
Forgot to remove llama benchmarking CI on pull_request for testing purposes.