### PR TITLE
fix missing 1st token from prefill in inference response

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -53,6 +53,7 @@ class GenerateItemProcess(sf.Process):
             # Prefill result.
             token = sfnp.argmax(exec.result_logits)
             token_int = token.items[0]
+            self.append_token(token_int)
 
             # Decode loop.
             # TODO: Use correct eot token from config.


### PR DESCRIPTION
The 1st output token is generated by prefill. It was missing.