### PR TITLE
[tuner] Use JSON for benchmark output

### DIFF
--- a/tuner/examples/dispatch/dispatch_tuner.py
+++ b/tuner/examples/dispatch/dispatch_tuner.py
@@ -58,6 +58,7 @@ class DispatchTuner(libtuner.TuningClient):
             f"--module={compiled_vmfb_path.resolve()}",
             "--batch_size=1000",
             "--benchmark_repetitions=3",
+            "--benchmark_format=json",
         ]
 
         return command

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -58,8 +58,7 @@ class PunetClient(libtuner.TuningClient):
             "--hip_allow_inline_execution=true",
             "--batch_size=1000",
             "--benchmark_repetitions=3",
-            f"--benchmark_out=dispatch_{candidate_tracker.candidate_id}_bm.json",
-            "--benchmark_out_format=json",
+            "--benchmark_format=json",
         ]
 
         return command
@@ -110,8 +109,7 @@ class PunetClient(libtuner.TuningClient):
             "--input=2x6xf16",
             "--input=1xf16",
             "--benchmark_repetitions=5",
-            f"--benchmark_out=model_{candidate_tracker.candidate_id}_bm.json",
-            "--benchmark_out_format=json",
+            "--benchmark_format=json",
         ]
         return command
 


### PR DESCRIPTION
### Notes:
- Splits `Configuration` into `LLVMGPUConfiguration` & `LLVMCPUConfiguration`
- Adds `device_target` to the `MlirRegex` dataclass
- Adds `*ConfigurationBuilder` for abstracting the building of configurations
- Adds `ConfigurationBuilderFactory` to fetch the proper configuration builder based on target architecture

### Tests:
N/A