### PR TITLE
Fix difference of LLM export for the direct vs paged cache

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -116,10 +116,9 @@ def main():
                 page_count=hp.context_length // llama_config.block_seq_stride
             )
             page_dim = torch.export.Dim("page")
-            dynamic_shapes = [{0: page_dim}]
 
+            dynamic_shapes = [{0: page_dim}]
             unpacked = cache_state
-            dynamic_shapes = dynamic_shapes
             arg_affinities = {}
             shard_dim = None
 

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -144,6 +144,7 @@ def main():
             #   [bs, seq_length, attn_head_count, attn_head_dim]
             dynamic_shapes = [None]
             arg_affinities = {}
+            shard_dim = None
             return torch.stack(cache_state), shard_dim, dynamic_shapes, arg_affinities
         else:
             raise NotImplementedError(f"Unsupported KV cache type: {type(model.cache)}")


### PR DESCRIPTION
Before work on unifying the cache interfaces there are some differences between sharded, direct and paged caches.
The direct cache uses a list of tensors for each transformer block while paged cache has on slab and paged sharded expect a list of shards.