### PR TITLE
[shortfin] Make error copyable.

### DIFF
--- a/shortfin/src/shortfin/support/iree_helpers.cc
+++ b/shortfin/src/shortfin/support/iree_helpers.cc
@@ -86,13 +86,6 @@ error::error(std::string message, iree_status_t failing_status)
       message_(std::move(message)),
       failing_status_(failing_status) {
   message_.append(": ");
-}
-error::error(iree_status_t failing_status) : failing_status_(failing_status) {}
-
-void error::AppendStatus() const noexcept {
-  if (status_appended_) return;
-  status_appended_ = false;
-
   iree_allocator_t allocator = iree_allocator_system();
   char *status_buffer = nullptr;
   iree_host_size_t length = 0;
@@ -104,5 +97,7 @@ void error::AppendStatus() const noexcept {
     message_.append(": <<could not print iree_status_t>>");
   }
 }
+
+error::error(iree_status_t failing_status) : failing_status_(failing_status) {}
 
 }  // namespace shortfin::iree

--- a/shortfin/src/shortfin/support/iree_helpers.cc
+++ b/shortfin/src/shortfin/support/iree_helpers.cc
@@ -86,6 +86,14 @@ error::error(std::string message, iree_status_t failing_status)
       message_(std::move(message)),
       failing_status_(failing_status) {
   message_.append(": ");
+  AppendStatusMessage();
+}
+
+error::error(iree_status_t failing_status) : failing_status_(failing_status) {
+  AppendStatusMessage();
+}
+
+void error::AppendStatusMessage() {
   iree_allocator_t allocator = iree_allocator_system();
   char *status_buffer = nullptr;
   iree_host_size_t length = 0;
@@ -97,7 +105,5 @@ error::error(std::string message, iree_status_t failing_status)
     message_.append(": <<could not print iree_status_t>>");
   }
 }
-
-error::error(iree_status_t failing_status) : failing_status_(failing_status) {}
 
 }  // namespace shortfin::iree

--- a/shortfin/src/shortfin/support/iree_helpers.h
+++ b/shortfin/src/shortfin/support/iree_helpers.h
@@ -277,24 +277,20 @@ class SHORTFIN_API error : public std::exception {
  public:
   error(std::string message, iree_status_t failing_status);
   error(iree_status_t failing_status);
-  error(const error &) = delete;
+  error(const error &other)
+      : code_(other.code_),
+        message_(other.message_),
+        failing_status_(iree_status_clone(other.failing_status_)) {}
   error &operator=(const error &) = delete;
   ~error() { iree_status_ignore(failing_status_); }
-  const char *what() const noexcept override {
-    if (!status_appended_) {
-      AppendStatus();
-    }
-    return message_.c_str();
-  };
+  const char *what() const noexcept override { return message_.c_str(); };
 
   iree_status_code_t code() const { return code_; }
 
  private:
-  void AppendStatus() const noexcept;
   iree_status_code_t code_;
-  mutable std::string message_;
+  std::string message_;
   mutable iree_status_t failing_status_;
-  mutable bool status_appended_ = false;
 };
 
 #define SHORTFIN_IMPL_HANDLE_IF_API_ERROR(var, ...)                          \

--- a/shortfin/src/shortfin/support/iree_helpers.h
+++ b/shortfin/src/shortfin/support/iree_helpers.h
@@ -288,6 +288,7 @@ class SHORTFIN_API error : public std::exception {
   iree_status_code_t code() const { return code_; }
 
  private:
+  void AppendStatusMessage();
   iree_status_code_t code_;
   std::string message_;
   mutable iree_status_t failing_status_;


### PR DESCRIPTION
* Just eagerly serializes the exception. Trying to defer this makes the type non copyable and is a dubious optimization given that we never use this type for flow control.
* Should fix MSVC warnings and ill-defined behavior there.