### PR TITLE
Replace commit hash with latest release candidate

### DIFF
--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -56,7 +56,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
+        ref: candidate-20241029.1062
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -56,7 +56,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
+        ref: candidate-20241029.1062
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -109,7 +109,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
+        ref: candidate-20241029.1062
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -57,7 +57,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
+        ref: candidate-20241029.1062
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -183,7 +183,7 @@ elseif (SHORTFIN_BUNDLE_DEPS)
   FetchContent_Declare(
     shortfin_iree
     GIT_REPOSITORY https://github.com/iree-org/iree.git
-    GIT_TAG 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
+    GIT_TAG candidate-20241029.1062
     GIT_SUBMODULES ${IREE_SUBMODULES}
     GIT_SHALLOW TRUE
     SYSTEM


### PR DESCRIPTION
Received following error when attempting to build shortfin after latest changes:

```text
[1/9] Performing download step (git clone) for 'shortfin_iree-populate'
      Cloning into 'shortfin_iree-src'...
      fatal: reference is not a tree: 67ba1c45424d5cedc7baf7bfe8a998ee86e510af
      CMake Error at shortfin_iree-subbuild/shortfin_iree-populate-prefix/tmp/shortfin_iree-populate-gitclone.cmake:61 (message):
        Failed to checkout tag: '67ba1c45424d5cedc7baf7bfe8a998ee86e510af'
```

This [PR](https://github.com/stbaione/SHARK-Platform/commit/e465c8331e78920ceadf9ea700c9487340628771#diff-35cb57ca809622770dcb077453d2d0982ba69588484a1ef6310b7450cc8568f4R186) seemed to introduce the bug by switching from `release candidate` tag to a `commit hash`.

Switched back to using release-candidate tag, which fixed shortfin building.