### PR TITLE
Expand testing to cover Python 3.11

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -38,6 +38,9 @@ jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
 
     steps:
     - name: Install dependencies
@@ -67,10 +70,10 @@ jobs:
         git submodule update --init --depth 1 -- third_party/googletest
         git submodule update --init --depth 1 -- third_party/hip-build-deps/
 
-    - name: Setup Python
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
-        python-version: "3.12"
+        python-version: ${{ matrix.python-version }}
         cache: "pip"
     - name: Install Python packages
       # TODO: Switch to `pip install -r requirements.txt -e shortfin/`.

--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -111,12 +111,12 @@ if DEV_MODE:
 
 # Due to a quirk of setuptools, that package_dir map must only contain
 # paths relative to the directory containing setup.py. Why? No one knows.
-REL_SOURCE_DIR = SOURCE_DIR.relative_to(SETUPPY_DIR, walk_up=True)
-REL_BINARY_DIR = BINARY_DIR.relative_to(SETUPPY_DIR, walk_up=True)
-REL_CMAKE_DEFAULT_BUILD_DIR = CMAKE_DEFAULT_BUILD_DIR.relative_to(
-    SETUPPY_DIR, walk_up=True
+REL_SOURCE_DIR = Path(os.path.relpath(SOURCE_DIR, SETUPPY_DIR))
+REL_BINARY_DIR = Path(os.path.relpath(BINARY_DIR, SETUPPY_DIR))
+REL_CMAKE_DEFAULT_BUILD_DIR = Path(
+    os.path.relpath(CMAKE_DEFAULT_BUILD_DIR, SETUPPY_DIR)
 )
-REL_CMAKE_TRACY_BUILD_DIR = CMAKE_TRACY_BUILD_DIR.relative_to(SETUPPY_DIR, walk_up=True)
+REL_CMAKE_TRACY_BUILD_DIR = Path(os.path.relpath(CMAKE_TRACY_BUILD_DIR, SETUPPY_DIR))
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
Further replaces `PurePath.relative_to` as the `walk_up` parameter was added with Python 3.12 and the old behavior defaults to `False`.

Progress on https://github.com/nod-ai/SHARK-Platform/issues/357