### PR TITLE
[sharktank] Modernize `setup.py` based project

### DIFF
--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -2,6 +2,44 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "sharktank"
+authors = [
+  {name = "SHARK Authors"},
+]
+description = "SHARK layers and inference models for genai"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+requires-python = ">= 3.11"
+dependencies = ["iree-turbine"]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+testing = ["pytest"]
+
+[project.urls]
+Repository = "https://github.com/nod-ai/SHARK-Platform"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sharktank*"]
+namespaces = true
+
+[tool.setuptools.package-data]
+sharktank = ["py.typed", "kernels/templates/*.mlir"]
+
+[tool.setuptools.dynamic]
+# version = {file = ["version_info"]}
+dependencies = {file = ["requirements.txt"]}
+
 [tool.pytest.ini_options]
 addopts = [
     "-ra",

--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11"
 dependencies = ["iree-turbine"]
-dynamic = ["version"]
+dynamic = ["version"]  # the version is set via the `setup.py`
 
 [project.optional-dependencies]
 testing = ["pytest"]
@@ -37,7 +37,6 @@ namespaces = true
 sharktank = ["py.typed", "kernels/templates/*.mlir"]
 
 [tool.setuptools.dynamic]
-# version = {file = ["version_info"]}
 dependencies = {file = ["requirements.txt"]}
 
 [tool.pytest.ini_options]

--- a/sharktank/setup.py
+++ b/sharktank/setup.py
@@ -6,23 +6,11 @@
 
 import json
 import os
-import distutils.command.build
 from pathlib import Path
 
-from setuptools import find_namespace_packages, setup  # type: ignore
+from setuptools import setup
 
 SETUPPY_DIR = os.path.realpath(os.path.dirname(__file__))
-
-
-with open(
-    os.path.join(
-        SETUPPY_DIR,
-        "README.md",
-    ),
-    "rt",
-) as f:
-    README = f.read()
-
 
 # Setup and get version information.
 VERSION_INFO_FILE = os.path.join(SETUPPY_DIR, "version_info.json")
@@ -36,72 +24,6 @@ def load_version_info():
 version_info = load_version_info()
 PACKAGE_VERSION = version_info["package-version"]
 
-packages = find_namespace_packages(
-    include=[
-        "sharktank",
-        "sharktank.*",
-    ],
-)
-
-print("Found packages:", packages)
-
-# Lookup version pins from requirements files.
-requirement_pins = {}
-
-
-def load_requirement_pins(requirements_file: Path):
-    with open(requirements_file, "rt") as f:
-        lines = f.readlines()
-    pin_pairs = [line.strip().split("==") for line in lines if "==" in line]
-    requirement_pins.update(dict(pin_pairs))
-
-
-load_requirement_pins("requirements.txt")
-
-
-def get_version_spec(dep: str):
-    if dep in requirement_pins:
-        return f">={requirement_pins[dep]}"
-    else:
-        return ""
-
-
-# Override build command so that we can build into _python_build
-# instead of the default "build". This avoids collisions with
-# typical CMake incantations, which can produce all kinds of
-# hilarity (like including the contents of the build/lib directory).
-class BuildCommand(distutils.command.build.build):
-    def initialize_options(self):
-        distutils.command.build.build.initialize_options(self)
-        self.build_base = "_python_build"
-
-
 setup(
-    name=f"sharktank",
     version=f"{PACKAGE_VERSION}",
-    author="SHARK Authors",
-    description="SHARK layers and inference models for genai",
-    long_description=README,
-    long_description_content_type="text/markdown",
-    url="https://github.com/nod-ai/SHARK-Platform",
-    license="Apache-2.0",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3",
-    ],
-    packages=packages,
-    include_package_data=True,
-    package_data={
-        "sharktank": ["py.typed", "kernels/templates/*.mlir"],
-    },
-    install_requires=[
-        "iree-turbine",
-    ],
-    extras_require={
-        "testing": [
-            f"pytest{get_version_spec('pytest')}",
-        ],
-    },
-    cmdclass={"build": BuildCommand},
 )


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-Platform/issues/294

Moves over the project metadata and most parts of the build configuration to the `pyproject.toml`, see [1, 2]. The `setup.py` is kept to allow handling `version_info.json` files in a similar manner across all our project.

[1] https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
[2] https://packaging.python.org/en/latest/guides/modernize-setup-py-project/