### PR TITLE
[ops] Add a sharded attention operation for SDPA

### DIFF
--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -171,12 +171,11 @@ class PagedLlamaAttentionBlock(ThetaLayer):
             )  # (bs, heads, slen, head_dim)
         else:
             is_causal = attention_mask is None and batch_seq_len == 1
-            attn_output = torch.nn.functional.scaled_dot_product_attention(
-                query=xq,  # [bs, ..., sl, dim]
-                key=keys,  # [bs, ..., sl, dim]
-                value=values,  # [bs, ..., sl, dim]
-                attn_mask=attention_mask,  # [bs, ..., sl, sl]
-                dropout_p=0.0,
+            attn_output = ops.scaled_dot_product_attention(
+                q=xq,  # [bs, ..., sl, dim]
+                k=keys,  # [bs, ..., sl, dim]
+                v=values,  # [bs, ..., sl, dim]
+                a=attention_mask,  # [bs, ..., sl, sl]
                 is_causal=is_causal,  # assumes causal masking when true
                 scale=None,  # defaults to 1/sqrt(dim)
             )

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -359,10 +359,8 @@ def matmul_default(lhs, rhs, *, transpose_rhs: bool) -> Tensor:
 
 
 # Scaled dot product attention
-@scaled_dot_product_attention.override(
-    Tensor, Tensor, Tensor, Optional[Tensor], auto_dequant=True
-)
-def scaled_dot_product_attention(q, k, v, a) -> Tensor:
+@scaled_dot_product_attention.override(Tensor, Tensor, Tensor, None)
+def scaled_dot_product_attention_torch(q, k, v, a, is_causal, scale) -> Tensor:
     q = unbox_tensor(q)
     k = unbox_tensor(k)
     v = unbox_tensor(v)
@@ -371,7 +369,7 @@ def scaled_dot_product_attention(q, k, v, a) -> Tensor:
 
     # TODO: plumb dropout and is_causal through ops
     return torch.nn.functional.scaled_dot_product_attention(
-        q, k, v, attn_mask=a, dropout_p=0.0, is_causal=False
+        q, k, v, attn_mask=a, dropout_p=0.0, is_causal=is_causal, scale=scale
     )
 
 

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -784,7 +784,7 @@ def _replicate_trampoline(
 
 @overridable
 def scaled_dot_product_attention(
-    q: AnyTensor, k: AnyTensor, v: AnyTensor, a: Optional[AnyTensor]
+    q: AnyTensor, k: AnyTensor, v: AnyTensor, a: Optional[AnyTensor], is_causal: bool
 ) -> AnyTensor:
     """Computes the scaled dot product attention using QKV."""
     raise NotImplementedError
@@ -797,10 +797,12 @@ def _scaled_dot_product_attention(
     k: AnyTensor,
     v: AnyTensor,
     a: Optional[AnyTensor],
+    is_causal: bool = False,
+    scale: Optional[float] = None,
 ):
     tensors = (q, k, v, a)
     for override in d.find_overrides(tensors):
-        result = override(q, k, v, a)
+        result = override(q, k, v, a, is_causal=is_causal, scale=scale)
         if result is not NotImplemented:
             return override, result
     else:


### PR DESCRIPTION
Existing implementation invokes the `torch` sdpa operator directly. Rewired to invoke via the `ops` system for a sharded sdpa operation. This includes a sharded implementation that compares the two versions.