### PR TITLE
Introduce CausalLMModelABC interface

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -174,7 +174,7 @@ def main():
             "tokens": {1: sl_dim},
             "seq_lens": {},
             "seq_block_ids": {1: block_dim},
-            "cs": cache_dynamic_shapes,
+            "cache_state": cache_dynamic_shapes,
         }
 
         print(f"Exporting prefill_bs{bs}")
@@ -186,39 +186,21 @@ def main():
             strict=args.strict,
             arg_device=arg_affinities,
         )
-        def _(model, tokens, seq_lens, seq_block_ids, cs):
+        def _(model, tokens, seq_lens, seq_block_ids, cache_state):
             if (
                 model.config.tensor_parallelism_size == 1
                 and model.config.kv_cache_type == "direct"
             ):
-                cache_tensors = torch.unbind(cs)
-            else:
-                cache_tensors = cs
+                cache_state = torch.unbind(cache_state)
+            if model.config.tensor_parallelism_size != 1:
+                cache_state = repack_cache(cache_state, cache_shard_dim)
 
-            sl = tokens.shape[1]
-            input_mask = model.input_mask(seq_lens, sl)
-            attention_mask = model.attention_mask(input_mask)
-
-            if llama_config.tensor_parallelism_size != 1:
-                shard_count = llama_config.tensor_parallelism_size
-
-                tokens = ops.replicate(tokens, count=shard_count)
-                attention_mask = ops.replicate(attention_mask, count=shard_count)
-                seq_block_ids = ops.replicate(seq_block_ids, count=shard_count)
-
-                cache_tensors = repack_cache(cs, cache_shard_dim)
-
-            logits = model.prefill(
-                tokens,
-                attention_mask=attention_mask,
+            return model.prefill_from_seq_lens(
+                tokens=tokens,
+                seq_lens=seq_lens,
                 seq_block_ids=seq_block_ids,
-                cache_state=cache_tensors,
+                cache_state=cache_state,
             )
-
-            if llama_config.tensor_parallelism_size != 1:
-                logits = ops.unshard(logits)
-
-            return logits
 
     def generate_batch_decode(bs: int):
         tokens = torch.ones(bs, 1, dtype=torch.int64)
@@ -274,33 +256,20 @@ def main():
             seq_block_ids,
             cache_state,
         ):
-            input_mask = model.input_mask(
-                seq_lens, seq_block_ids.shape[1] * model.cache.block_seq_stride
-            )
-            attention_mask = model.decode_attention_mask(input_mask)
-
-            if llama_config.tensor_parallelism_size != 1:
-                shard_count = llama_config.tensor_parallelism_size
-
-                tokens = ops.replicate(tokens, count=shard_count)
-                attention_mask = ops.replicate(attention_mask, count=shard_count)
-                start_positions = ops.replicate(start_positions, count=shard_count)
-                seq_block_ids = ops.replicate(seq_block_ids, count=shard_count)
-
+            if (
+                model.config.tensor_parallelism_size == 1
+                and model.config.kv_cache_type == "direct"
+            ):
+                cache_state = torch.unbind(cache_state)
+            if model.config.tensor_parallelism_size != 1:
                 cache_state = repack_cache(cache_state, cache_shard_dim)
-
-            logits = model.decode(
-                tokens,
-                attention_mask=attention_mask,
+            return model.decode_from_seq_lens(
+                tokens=tokens,
+                seq_lens=seq_lens,
                 start_positions=start_positions,
                 seq_block_ids=seq_block_ids,
                 cache_state=cache_state,
             )
-
-            if llama_config.tensor_parallelism_size != 1:
-                logits = ops.unshard(logits)
-
-            return logits
 
     bsizes = []
     for bs in args.bs:

--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -7,7 +7,10 @@
 from .base import BaseLayer, ThetaLayer
 from .conv import Conv2DLayer
 from .kv_cache import BaseKVCache, DirectKVCache, PagedKVCache
-from .causal_llm import BaseCausalLMModel
+from .causal_llm import (
+    CausalLMModelABC,
+    BaseCausalLMModel,
+)
 from .linear import LinearLayer
 from .norm import RMSNormLayer
 from .rotary_embedding import RotaryEmbeddingLayer

--- a/sharktank/sharktank/models/grok/grok.py
+++ b/sharktank/sharktank/models/grok/grok.py
@@ -26,7 +26,7 @@ __all__ = [
 ################################################################################
 
 
-class PagedGrokModelV1(BaseCausalLMModel):
+class PagedGrokModelV1(BaseCausalLMModel, CausalLMModelABC):
     """Grok model with a paged KV cache and supporting variable sequence
     length batched inference.
 
@@ -50,8 +50,8 @@ class PagedGrokModelV1(BaseCausalLMModel):
 
     def __init__(self, theta: Theta, config: LlamaModelConfig):
         hp = config.hp
-        super().__init__(
-            theta,
+        BaseCausalLMModel.__init__(
+            self,
             context_length=config.hp.context_length,
             device=config.device,
             activation_dtype=config.activation_dtype,

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -7,7 +7,7 @@
 from typing import Optional
 
 from dataclasses import dataclass
-from typing import Union
+from typing import Any, Union
 
 import torch
 import torch.nn as nn
@@ -27,7 +27,7 @@ __all__ = [
 ################################################################################
 
 
-class PagedLlamaModelV1(BaseCausalLMModel):
+class PagedLlamaModelV1(BaseCausalLMModel, CausalLMModelABC):
     """LlamaModel with a paged KV cache and supporting variable sequence
     length batched inference.
 
@@ -64,8 +64,8 @@ class PagedLlamaModelV1(BaseCausalLMModel):
 
     def __init__(self, theta: Theta, config: LlamaModelConfig):
         hp = config.hp
-        super().__init__(
-            theta,
+        BaseCausalLMModel.__init__(
+            self,
             context_length=config.hp.context_length,
             static_tables=config.static_tables,
             device=config.device,

--- a/sharktank/sharktank/models/mixtral/mixtral.py
+++ b/sharktank/sharktank/models/mixtral/mixtral.py
@@ -28,7 +28,7 @@ __all__ = [
 ################################################################################
 
 
-class PagedMixtralModelV1(BaseCausalLMModel):
+class PagedMixtralModelV1(BaseCausalLMModel, CausalLMModelABC):
     """MixtralModel with a paged KV cache and supporting variable sequence
     length batched inference.
 
@@ -52,8 +52,8 @@ class PagedMixtralModelV1(BaseCausalLMModel):
 
     def __init__(self, theta: Theta, config: LlamaModelConfig):
         hp = config.hp
-        super().__init__(
-            theta,
+        BaseCausalLMModel.__init__(
+            self,
             context_length=config.hp.context_length,
             device=config.device,
             activation_dtype=config.activation_dtype,

--- a/sharktank/tests/models/llama/kv_cache_test.py
+++ b/sharktank/tests/models/llama/kv_cache_test.py
@@ -107,9 +107,7 @@ class KVCacheTest(unittest.TestCase):
         self.embedding_batch_mask = self.attention_embedding.compute_batch_mask(
             self.start_positions, batch_seq_len=1
         )
-        self.model = causal_llm.BaseCausalLMModel(
-            self.attention_block_theta, context_length=self.max_seq_len
-        )
+        self.model = causal_llm.BaseCausalLMModel(context_length=self.max_seq_len)
         self.prefill_attention_mask = self.model.attention_mask(
             self.model.input_mask(self.start_positions, self.seq_len)
         )


### PR DESCRIPTION
We do not have a clearly defined interface for LMs. Decode and prefill have different signature when exporting to IREE. Here is added a new ABC CausalLMModelABC that makes a distinction between the two variants. The BaseCausalLMModel provides a default implementation for the new prefill_from_seq_lens and decode_from_seq_lens methods.

The export script export_paged_llm_v1 does too much in its exported functions. It computes the attention mask then. It shards its arguments and unshards its result. This change lets it be a thiner wrapper around the new interface functions.

Make paged_llm_v1.TorchGenerator use the new interface methods.