### PR TITLE
Add method to_gguf_props in LlamaHParams

### DIFF
--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -80,6 +80,27 @@ class LlamaHParams:
             ),
         )
 
+    def to_gguf_props(self) -> dict[str, Any]:
+        res = {
+            "general.architecture": self.model_arch,
+            f"{self.model_arch}.context_length": self.context_length,
+            f"{self.model_arch}.embedding_length": self.embedding_length,
+            f"{self.model_arch}.block_count": self.block_count,
+            f"{self.model_arch}.feed_forward_length": self.feed_forward_length,
+            f"{self.model_arch}.attention.head_count": self.attention_head_count,
+            f"{self.model_arch}.attention.layer_norm_rms_epsilon": self.attention_layer_norm_rms_epsilon,
+            f"{self.model_arch}.attention.head_count_kv": self.attention_head_count_kv,
+        }
+        if self.rope_dimension_count is not None:
+            res[f"{self.model_arch}.rope.dimension_count"] = self.rope_dimension_count
+        if self.rope_freq_base is not None:
+            res[f"{self.model_arch}.rope.freq_base"] = self.rope_freq_base
+        if self.expert_count is not None:
+            res[f"{self.model_arch}.expert_count"] = self.expert_count
+        if self.expert_used_count is not None:
+            res[f"{self.model_arch}.expert_used_count"] = self.expert_used_count
+        return res
+
 
 def _float_prop(p: dict[str, Any], name: str) -> float:
     try:

--- a/sharktank/tests/layers/configs_test.py
+++ b/sharktank/tests/layers/configs_test.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.layers.configs import LlamaHParams
+
+
+def test_llama_hp_params_to_from_gguf_props_roundtrip():
+    params = LlamaHParams(
+        model_arch="llama",
+        context_length=1,
+        embedding_length=2,
+        block_count=3,
+        feed_forward_length=3,
+        rope_dimension_count=4,
+        rope_freq_base=5.0,
+        attention_head_count=6,
+        attn_head_dim=4,
+        attention_layer_norm_rms_epsilon=8.0,
+        attention_head_count_kv=9,
+        expert_count=10,
+        expert_used_count=11,
+    )
+    roundtripped_params = LlamaHParams.from_gguf_props(params.to_gguf_props())
+    assert params == roundtripped_params


### PR DESCRIPTION
Some upcoming tests use this to construct a dataset file with a config.