### PR TITLE
Add class that implements CausalLMModelABC but is backed by an IREE module

### DIFF
--- a/sharktank/sharktank/layers/testing.py
+++ b/sharktank/sharktank/layers/testing.py
@@ -4,10 +4,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from typing import Union
+
 import torch
 from ..types.theta import Theta
-from ..types.tensors import DefaultPrimitiveTensor
+from ..types.tensors import DefaultPrimitiveTensor, SplitPrimitiveTensor
 from ..utils.testing import make_rand_torch
+from ..utils.create_cache import create_kv_cache
+from ..layers import CausalLMModelABC, BaseCausalLMModel, LlamaModelConfig
+from ..utils.iree import (
+    run_iree_module_function,
+    prepare_iree_module_function_args,
+    iree_to_torch,
+)
+import iree.runtime
 
 
 def make_llama_attention_block_theta(
@@ -43,3 +53,106 @@ def make_llama_attention_block_theta(
             ),
         }
     )
+
+
+class CausalLMIreeModel(BaseCausalLMModel, CausalLMModelABC):
+    """Implements CausalLMModelABC where prefill_from_seq_lens and decode_from_seq_lens
+    are backed by an IREE module.
+    This is meant only for testing. It may not be performant as it marshals tensors and
+    uses the IREE Python bindings."""
+
+    def __init__(
+        self,
+        config: LlamaModelConfig,
+        batch_size: int,
+        vm_context: iree.runtime.VmContext,
+        iree_driver: str,
+        iree_module: iree.runtime.VmModule,
+        iree_devices: list[iree.runtime.HalDevice],
+    ):
+        # TODO: figure out why doing
+        # super(BaseCausalLMModel, self).__init__(...)
+        # instead spooks torch.nn.Module with
+        # TypeError: CausalLMIreeModel.__init__() got an unexpected keyword argument
+        # 'context_length'
+        BaseCausalLMModel.__init__(
+            self,
+            context_length=config.hp.context_length,
+            device=config.device,
+            activation_dtype=config.activation_dtype,
+            attention_dtype=config.attention_dtype,
+        )
+        self.config = config
+        self.cache = create_kv_cache(self.config)
+        self.vm_context = vm_context
+        self.iree_driver = iree_driver
+        self.iree_module = iree_module
+        self.iree_devices = iree_devices
+        self.batch_size = batch_size
+
+    def prefill(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def prefill_from_seq_lens(
+        self,
+        tokens: torch.Tensor,
+        *,
+        seq_lens: torch.Tensor,
+        seq_block_ids: torch.Tensor,
+        cache_state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+    ):
+        iree_args = prepare_iree_module_function_args(
+            args=[tokens, seq_lens, seq_block_ids, cache_state],
+            devices=self.iree_devices,
+        )
+        iree_results = run_iree_module_function(
+            args=iree_args,
+            function_name=f"prefill_bs{self.batch_size}",
+            module=self.iree_module,
+            vm_context=self.vm_context,
+            driver=self.iree_driver,
+        )
+
+        iree_cache_state_shards = iree_args[-self.config.tensor_parallelism_size :]
+        iree_cache_state = SplitPrimitiveTensor(
+            ts=iree_to_torch(*iree_cache_state_shards),
+            shard_dim=1,
+        )
+        cache_state[0][...] = iree_cache_state
+
+        iree_results = iree_to_torch(*iree_results)
+        return iree_results[0]
+
+    def decode(self, *args, **kwargs):
+        raise NotImplementedError()
+
+    def decode_from_seq_lens(
+        self,
+        tokens: torch.Tensor,
+        *,
+        seq_lens: torch.Tensor,
+        start_positions: torch.Tensor,
+        seq_block_ids: torch.Tensor,
+        cache_state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+    ):
+        iree_args = prepare_iree_module_function_args(
+            args=[tokens, seq_lens, start_positions, seq_block_ids, cache_state],
+            devices=self.iree_devices,
+        )
+        iree_results = run_iree_module_function(
+            args=iree_args,
+            function_name=f"decode_bs{self.batch_size}",
+            module=self.iree_module,
+            vm_context=self.vm_context,
+            driver=self.iree_driver,
+        )
+
+        iree_cache_state_shards = iree_args[-self.config.tensor_parallelism_size :]
+        iree_cache_state = SplitPrimitiveTensor(
+            ts=iree_to_torch(*iree_cache_state_shards),
+            shard_dim=1,
+        )
+        cache_state[0][...] = iree_cache_state
+
+        iree_results = iree_to_torch(*iree_results)
+        return iree_results[0]


### PR DESCRIPTION
This is meant only for testing. It may not be performant as it marshals tensors and uses the IREE Python bindings.