### PR TITLE
Don't run on workflow on PR

### DIFF
--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -7,7 +7,6 @@
 name: Evaluation Tests
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays nightly at 07:00 UTC = 23:00 PST / 00:00 PDT.


### PR DESCRIPTION
Partly reverts changes pushed with commit b7fa50c. The workflow seems to take hour and is not suitable to run on every PR.