### PR TITLE
Build sharktank packages nightly.

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -59,6 +59,7 @@ jobs:
           - runs-on: ubuntu-24.04
             platform: linux-x86_64
             package: sharktank
+            python-version: cp311-cp311  # Ignored (generic wheel), set for workflow naming
           - runs-on: ubuntu-24.04
             platform: linux-x86_64
             package: shortfin

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -58,6 +58,9 @@ jobs:
           # Ubuntu packages.
           - runs-on: ubuntu-24.04
             platform: linux-x86_64
+            package: sharktank
+          - runs-on: ubuntu-24.04
+            platform: linux-x86_64
             package: shortfin
             python-version: cp312-cp312
           - runs-on: ubuntu-24.04
@@ -71,7 +74,6 @@ jobs:
 
           # TODO(#130): macOS platform
           # TODO(#130): Windows platform
-          # TODO(#130): sharktank packages
 
     steps:
     - name: Checkout repository
@@ -86,6 +88,14 @@ jobs:
         name: version_info_rc
         path: ./c/
         merge-multiple: true
+
+    - name: Build sharktank (Linux x86_64)
+      if: "matrix.package == 'sharktank' && matrix.platform == 'linux-x86_64'"
+      env:
+        OUTPUT_DIR: "${{ github.workspace }}/bindist"
+      run: |
+        [ -e ./bindist/* ] && rm ./bindist/*
+        ./c/sharktank/build_tools/build_linux_package.sh
 
     - name: Build shortfin (Linux x86_64, ${{ matrix.python-version }})
       if: "matrix.package == 'shortfin' && matrix.platform == 'linux-x86_64'"

--- a/sharktank/README.md
+++ b/sharktank/README.md
@@ -53,7 +53,7 @@ python -m sharktank.tools.dump_gguf --hf-dataset=open_llama_3b_v2_f16_gguf
 
     ```bash
     # Build sharktank.*.whl into the dist/ directory
-    #   e.g. `sharktank-3.0.0.dev0-py3-non-any.whl`
+    #   e.g. `sharktank-3.0.0.dev0-py3-none-any.whl`
     python3 -m pip wheel -v -w dist .
 
     # Install the built wheel.

--- a/sharktank/README.md
+++ b/sharktank/README.md
@@ -40,3 +40,22 @@ python -m sharktank.examples.export_paged_llm_v1 \
 ```shell
 python -m sharktank.tools.dump_gguf --hf-dataset=open_llama_3b_v2_f16_gguf
 ```
+
+## Package Python Release Builds
+
+* To build wheels for Linux:
+
+    ```bash
+    sudo ./build_tools/build_linux_package.sh
+    ```
+
+* To build a wheel for your host OS/arch manually:
+
+    ```bash
+    # Build sharktank.*.whl into the dist/ directory
+    #   e.g. `sharktank-3.0.0.dev0-py3-non-any.whl`
+    python3 -m pip wheel -v -w dist .
+
+    # Install the built wheel.
+    python3 -m pip install dist/*.whl
+    ```

--- a/sharktank/build_tools/build_linux_package.sh
+++ b/sharktank/build_tools/build_linux_package.sh
@@ -19,12 +19,7 @@ THIS_DIR="$(cd $(dirname $0) && pwd)"
 REPO_ROOT="$(cd "$THIS_DIR"/../../ && pwd)"
 OUTPUT_DIR="${OUTPUT_DIR:-${THIS_DIR}/wheelhouse}"
 
-python -m pip wheel --disable-pip-version-check -v -w "${OUTPUT_DIR}" "${REPO_ROOT}/sharktank"
+python -m pip wheel --disable-pip-version-check --no-deps -v -w "${OUTPUT_DIR}" "${REPO_ROOT}/sharktank"
 
 wheel_output="$(echo "${OUTPUT_DIR}/sharktank-"*".whl")"
 ls "${wheel_output}"
-
-echo "Deleting other wheels"
-pushd ${OUTPUT_DIR}
-ls | grep -xv "sharktank-"*".whl" | xargs rm
-popd

--- a/sharktank/build_tools/build_linux_package.sh
+++ b/sharktank/build_tools/build_linux_package.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# build_linux_package.sh
+#
+# Builds sharktank Python package for Linux
+#
+# Usage:
+#   ./build_tools/build_linux_package.sh
+
+set -xeu -o errtrace
+
+THIS_DIR="$(cd $(dirname $0) && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR"/../../ && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-${THIS_DIR}/wheelhouse}"
+
+python -m pip wheel --disable-pip-version-check -v -w "${OUTPUT_DIR}" "${REPO_ROOT}/sharktank"
+
+wheel_output="$(echo "${OUTPUT_DIR}/sharktank-"*".whl")"
+ls "${wheel_output}"

--- a/sharktank/build_tools/build_linux_package.sh
+++ b/sharktank/build_tools/build_linux_package.sh
@@ -23,3 +23,8 @@ python -m pip wheel --disable-pip-version-check -v -w "${OUTPUT_DIR}" "${REPO_RO
 
 wheel_output="$(echo "${OUTPUT_DIR}/sharktank-"*".whl")"
 ls "${wheel_output}"
+
+echo "Deleting other wheels"
+pushd ${OUTPUT_DIR}
+ls | grep -xv "sharktank-"*".whl" | xargs rm
+popd

--- a/shortfin/build_tools/build_linux_package.sh
+++ b/shortfin/build_tools/build_linux_package.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # build_linux_package.sh
-# One stop build of shortfin Python package for Linux. The Linux build is
+# One stop build of shortfin Python packages for Linux. The Linux build is
 # complicated because it has to be done via a manylinux docker container.
 #
 # Usage:


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-Platform/issues/294. Once this is merged the nightly package builds will start pushing `sharktank-{VERSION}-py3-none-any.whl` to https://github.com/nod-ai/SHARK-Platform/releases/tag/dev-wheels alongside the existing shortfin wheels.

Tested at https://github.com/ScottTodd/SHARK-Platform/actions/runs/11621153296/job/32364368882 (ignore the push failure at the end, missing a token).

---

Note that the 250KB Python wheel can be _installed_ standalone, but actually _using_ it will need version bumps across projects and more work. In particular, I hit

1. Using iree-turbine from pypi:
    ```
    from sharktank import ops
    ...

    ImportError: cannot import name 'dynamic_dim' from 'torch.export' (/home/nod/dev/scratch/shark-platform/3.11.venv/lib/python3.11/site-packages/torch/export/__init__.py)
    ```
    That may be fixed by https://github.com/iree-org/iree-turbine/pull/233
2. After installing iree-turbine from source:
    ```
    from sharktank import ops
    ...

        from gguf import GGUFReader, GGUFValueType
    ModuleNotFoundError: No module named 'gguf'
    ```

Full logs here: https://gist.github.com/ScottTodd/4cd0c343a92375e7fbdaaf37c38bfc06