### PR TITLE
Adapt sharktank/serving_poc to latest IREE runtime changes.

### DIFF
--- a/sharktank/sharktank/serving_poc/framework/session.py
+++ b/sharktank/sharktank/serving_poc/framework/session.py
@@ -319,7 +319,7 @@ class WorkQueue:
         self._semaphore = session.device.create_semaphore(0)
         self._step = 0
 
-    def execute_sequential(self, command_buffers: list[HalCommandBuffer]):
+    def execute_sequential(self, command_buffer: HalCommandBuffer):
         """Executes a list of command buffers at the current step, advancing to the
         next.
         """
@@ -329,7 +329,7 @@ class WorkQueue:
             self._step = next_step
         sem = self._semaphore
         self._device.queue_execute(
-            command_buffers, [(sem, current_step)], [(sem, next_step)]
+            command_buffer, [(sem, current_step)], [(sem, next_step)]
         )
 
     def current_fence(self) -> HalFence:

--- a/sharktank/sharktank/serving_poc/llm/impl/service_v1.py
+++ b/sharktank/sharktank/serving_poc/llm/impl/service_v1.py
@@ -340,7 +340,7 @@ class GenerateState(BatchGenerateState):
 
         # Perform h2d transfers.
         cb.end()
-        work_queue.execute_sequential([cb])
+        work_queue.execute_sequential(cb)
 
         # Inputs:
         #   token_ids
@@ -468,7 +468,7 @@ class GenerateState(BatchGenerateState):
 
         # Perform h2d transfers.
         cb.end()
-        work_queue.execute_sequential([cb])
+        work_queue.execute_sequential(cb)
 
         # Inputs:
         #   token_ids


### PR DESCRIPTION
The sharktank CI has been failing since the latest IREE nightly was automatically picked up: https://github.com/nod-ai/SHARK-Platform/actions/workflows/ci-sharktank.yml. We have version pins in many parts of this repository but apparently not here.

This fixes the failing test by adapting to the changes in https://github.com/iree-org/iree/pull/19000 that switched the low level `queue_execute` API from taking a list of command buffers to taking a single command buffer.