### PR TITLE
Integrate IREE at iree-org/iree@44adc3a

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -70,8 +70,8 @@ jobs:
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-compiler==20241104.1068 \
-            iree-runtime==20241104.1068 \
+            iree-compiler==20241106.1070 \
+            iree-runtime==20241106.1070 \
             "numpy<2.0"
 
       - name: Run llama tests

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -71,8 +71,8 @@ jobs:
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-compiler==20241104.1068 \
-            iree-runtime==20241104.1068 \
+            iree-compiler==20241106.1070 \
+            iree-runtime==20241106.1070 \
             "numpy<2.0"
 
       - name: Run llama 8b tests

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -64,7 +64,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: candidate-20241104.1068
+        ref: candidate-20241106.1070
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -59,7 +59,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: candidate-20241104.1068
+        ref: candidate-20241106.1070
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -109,7 +109,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: candidate-20241104.1068
+        ref: candidate-20241106.1070
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -57,7 +57,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: candidate-20241104.1068
+        ref: candidate-20241106.1070
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_windows_x64-libshortfin.yml
+++ b/.github/workflows/ci_windows_x64-libshortfin.yml
@@ -54,7 +54,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: candidate-20241104.1068
+        ref: candidate-20241106.1070
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -183,7 +183,7 @@ elseif (SHORTFIN_BUNDLE_DEPS)
   FetchContent_Declare(
     shortfin_iree
     GIT_REPOSITORY https://github.com/iree-org/iree.git
-    GIT_TAG candidate-20241104.1068
+    GIT_TAG candidate-20241106.1070
     GIT_SUBMODULES ${IREE_SUBMODULES}
     GIT_SHALLOW TRUE
     SYSTEM

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with IREE_REF in CI and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-compiler==20241104.1068
-iree-runtime==20241104.1068
+iree-compiler==20241106.1070
+iree-runtime==20241106.1070

--- a/shortfin/src/shortfin/array/storage.cc
+++ b/shortfin/src/shortfin/array/storage.cc
@@ -111,7 +111,7 @@ void storage::fill(const void *pattern, iree_host_size_t pattern_length) {
             iree_hal_make_buffer_ref(
                 buffer_, /*offset=*/0,
                 /*length=*/iree_hal_buffer_byte_length(buffer_)),
-            pattern, pattern_length));
+            pattern, pattern_length, IREE_HAL_FILL_FLAG_NONE));
 
         // And move our own mutation barrier to the current pending timeline
         // value.
@@ -139,7 +139,8 @@ void storage::copy_from(storage &source_storage) {
             /*source_ref=*/
             iree_hal_make_buffer_ref(source_storage.buffer_, 0, byte_length()),
             /*target_ref=*/
-            iree_hal_make_buffer_ref(buffer_, 0, byte_length())));
+            iree_hal_make_buffer_ref(buffer_, 0, byte_length()),
+            IREE_HAL_COPY_FLAG_NONE));
 
         // Move our own mutation barrier to the current pending timeline
         // value.

--- a/shortfin/src/shortfin/local/scheduler.cc
+++ b/shortfin/src/shortfin/local/scheduler.cc
@@ -275,9 +275,8 @@ iree_status_t Scheduler::FlushWithStatus() noexcept {
             .semaphores = &signal_sem,
             .payload_values = &signal_timepoint,
         },
-        /*command_buffer_count=*/1,
-        /*command_buffers=*/&active_command_buffer,
-        /*binding_tables=*/&binding_tables));
+        /*command_buffers=*/active_command_buffer,
+        /*binding_tables=*/binding_tables));
     account.Reset();
   }
   return iree_ok_status();


### PR DESCRIPTION
Updates IREE usage in shortfin to match iree-org/iree@44adc3a and candidate-20241106.1070, respectively. Further bumps to the new version in the workflows that are pinned to a specific version.