### PR TITLE
[shortfin] Add options to set allocators and logical devices per physical.

### DIFF
--- a/shortfin/examples/python/mobilenet_server/build_model.sh
+++ b/shortfin/examples/python/mobilenet_server/build_model.sh
@@ -39,5 +39,11 @@ echo "Import onnx model"
 python -m iree.compiler.tools.import_onnx $onnx_upgrade_path -o $mlir_path
 
 echo "Compile onnx model"
-python -m iree.compiler.tools.scripts.ireec \
-    $mlir_path -o "$vmfb_path" --iree-input-type=onnx --iree-hal-target-backends=llvm-cpu
+if [ -z "$@" ]; then
+    compile_flags="--iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=host"
+else
+    compile_flags="$@"
+fi
+echo "Using compile flags: $compile_flags"
+python -m iree.compiler.tools.scripts.iree_compile \
+    $mlir_path -o "$vmfb_path" --iree-input-type=onnx $compile_flags

--- a/shortfin/examples/python/mobilenet_server/inference_system.py
+++ b/shortfin/examples/python/mobilenet_server/inference_system.py
@@ -144,7 +144,8 @@ def run_cli(home_dir: Path, argv):
         # Done.
         writer.close()
 
-    lsys = sf.host.CPUSystemBuilder().create_system()
+    sf.SystemBuilder.default_system_type = "hostcpu"
+    lsys = sf.SystemBuilder().create_system()
     main = Main(lsys, home_dir)
     lsys.init_worker.call_threadsafe(client)
     lsys.run(main.main())

--- a/shortfin/src/shortfin/local/CMakeLists.txt
+++ b/shortfin/src/shortfin/local/CMakeLists.txt
@@ -35,6 +35,7 @@ shortfin_cc_component(
     iree_base_base
     iree_base_loop_sync
     iree_hal_hal
+    iree_hal_utils_allocators
     iree_io_formats_parser_registry
     iree_modules_io_parameters_parameters
     iree_modules_hal_hal

--- a/shortfin/src/shortfin/local/system.h
+++ b/shortfin/src/shortfin/local/system.h
@@ -249,6 +249,27 @@ class SHORTFIN_API SystemBuilder {
   // Construct a System
   virtual SystemPtr CreateSystem() = 0;
 
+ protected:
+  // Uses the iree_hal_configure_allocator_from_specs() API to configure
+  // allocators for a device. The specs are parsed from the given config_key
+  // if it exists and take the form:
+  //   some_allocator
+  //   some_allocator:key=value
+  //   some_allocator:key=value,key=value
+  //   some_allocator:key=value,key=value;other_allocator:key=value
+  void ConfigureAllocators(const std::vector<std::string> &specs,
+                           iree_hal_device_t *device,
+                           std::string_view device_debug_desc);
+
+  // Gets a list of allocator specs from the config. If `specific_config_key`
+  // is given, this will be consulted first and used if available. Otherwise,
+  // "allocators" will be used. For SystemBuilders that handle multiple
+  // device types, the specific key will be something like "amdgpu_allocators"
+  // or "hostcpu_allocators" and will be used to allow independently scoped
+  // allocator specs.
+  std::vector<std::string> GetConfigAllocatorSpecs(
+      std::optional<std::string_view> specific_config_key);
+
  private:
   const iree_allocator_t host_allocator_;
   ConfigOptions config_options_;

--- a/shortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/shortfin/src/shortfin/local/systems/amdgpu.cc
@@ -22,6 +22,7 @@ AMDGPUSystemBuilder::AMDGPUSystemBuilder(iree_allocator_t host_allocator,
       available_devices_(host_allocator) {
   iree_hal_hip_device_params_initialize(&default_device_params_);
   InitializeDefaultSettings();
+  config_options().ValidateUndef();
 }
 
 AMDGPUSystemBuilder::~AMDGPUSystemBuilder() = default;
@@ -41,6 +42,10 @@ void AMDGPUSystemBuilder::InitializeDefaultSettings() {
     }
   }
 
+  // Gets allocator specs from either "amdgpu_allocators" or the fallback
+  // "allocators".
+  amdgpu_allocator_specs_ = GetConfigAllocatorSpecs("amdgpu_allocators");
+
   // HIP options.
   // "amdgpu_tracing_level": Matches IREE flag --hip_tracing:
   // Permissible values are:
@@ -50,6 +55,13 @@ void AMDGPUSystemBuilder::InitializeDefaultSettings() {
   auto tracing_level =
       config_options().GetInt("amdgpu_tracing_level", /*non_negative=*/true);
   default_device_params_.stream_tracing = tracing_level ? *tracing_level : 2;
+
+  // Override logical_devices_per_physical_device if present.
+  auto logical_devices_per_physical_device = config_options().GetInt(
+      "amgdpu_logical_devices_per_physical_device", /*non_negative=*/true);
+  if (logical_devices_per_physical_device) {
+    logical_devices_per_physical_device_ = *logical_devices_per_physical_device;
+  }
 
   // CPU devices.
   cpu_devices_enabled_ = config_options().GetBool("amdgpu_cpu_devices_enabled");
@@ -176,21 +188,27 @@ SystemPtr AMDGPUSystemBuilder::CreateSystem() {
   for (size_t instance_ordinal = 0; instance_ordinal < used_device_ids.size();
        ++instance_ordinal) {
     iree_hal_device_id_t device_id = used_device_ids[instance_ordinal];
-    iree::hal_device_ptr device;
-    SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
-        hip_hal_driver_, device_id, 0, nullptr, host_allocator(),
-        device.for_output()));
-    lsys->InitializeHalDevice(std::make_unique<AMDGPUDevice>(
-        DeviceAddress(
-            /*system_device_class=*/SYSTEM_DEVICE_CLASS,
-            /*logical_device_class=*/LOGICAL_DEVICE_CLASS,
-            /*hal_driver_prefix=*/HAL_DRIVER_PREFIX,
-            /*instance_ordinal=*/instance_ordinal,
-            /*queue_ordinal=*/0,
-            /*instance_topology_address=*/{0}),
-        /*hal_device=*/device,
-        /*node_affinity=*/0,
-        /*capabilities=*/static_cast<uint32_t>(Device::Capabilities::NONE)));
+    for (size_t logical_index = 0;
+         logical_index < logical_devices_per_physical_device_;
+         ++logical_index) {
+      iree::hal_device_ptr device;
+      SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
+          hip_hal_driver_, device_id, 0, nullptr, host_allocator(),
+          device.for_output()));
+      DeviceAddress address(
+          /*system_device_class=*/SYSTEM_DEVICE_CLASS,
+          /*logical_device_class=*/LOGICAL_DEVICE_CLASS,
+          /*hal_driver_prefix=*/HAL_DRIVER_PREFIX,
+          /*instance_ordinal=*/instance_ordinal,
+          /*queue_ordinal=*/0,
+          /*instance_topology_address=*/{logical_index});
+      ConfigureAllocators(amdgpu_allocator_specs_, device, address.device_name);
+      lsys->InitializeHalDevice(std::make_unique<AMDGPUDevice>(
+          address,
+          /*hal_device=*/device,
+          /*node_affinity=*/0,
+          /*capabilities=*/static_cast<uint32_t>(Device::Capabilities::NONE)));
+    }
   }
 
   // Initialize CPU devices if requested.

--- a/shortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/shortfin/src/shortfin/local/systems/amdgpu.cc
@@ -58,7 +58,7 @@ void AMDGPUSystemBuilder::InitializeDefaultSettings() {
 
   // Override logical_devices_per_physical_device if present.
   auto logical_devices_per_physical_device = config_options().GetInt(
-      "amgdpu_logical_devices_per_physical_device", /*non_negative=*/true);
+      "amdgpu_logical_devices_per_physical_device", /*non_negative=*/true);
   if (logical_devices_per_physical_device) {
     logical_devices_per_physical_device_ = *logical_devices_per_physical_device;
   }

--- a/shortfin/src/shortfin/local/systems/amdgpu.h
+++ b/shortfin/src/shortfin/local/systems/amdgpu.h
@@ -57,7 +57,25 @@ class SHORTFIN_API AMDGPUSystemBuilder : public HostCPUSystemBuilder {
     return visible_devices_;
   };
 
+  // Allocator specs to apply to amdgpu devices in this builder.
+  std::vector<std::string> &amdgpu_allocator_specs() {
+    return amdgpu_allocator_specs_;
+  }
+
+  // "amdgpu_tracing_level": Matches IREE flag --hip_tracing:
+  // Permissible values are:
+  //   0 : stream tracing disabled.
+  //   1 : coarse command buffer level tracing enabled.
+  //   2 : fine-grained kernel level tracing enabled.
   int32_t &tracing_level() { return default_device_params_.stream_tracing; }
+
+  // The number of logical HAL devices to create per physical, visible device.
+  // This form of topology can be useful in certain cases where we aim to have
+  // oversubscription emulating what would usually be achieved with process
+  // level isolation. Defaults to 1.
+  size_t &logical_devices_per_physical_device() {
+    return logical_devices_per_physical_device_;
+  }
 
   // Gets all enumerated available device ids. This triggers enumeration, so
   // any settings required for that must already be set. This does no filtering
@@ -77,6 +95,8 @@ class SHORTFIN_API AMDGPUSystemBuilder : public HostCPUSystemBuilder {
   bool cpu_devices_enabled_ = false;
   std::vector<std::string> hip_lib_search_paths_;
   std::optional<std::vector<std::string>> visible_devices_;
+  size_t logical_devices_per_physical_device_ = 1;
+  std::vector<std::string> amdgpu_allocator_specs_;
 
   // Valid post enumeration.
   iree::hal_driver_ptr hip_hal_driver_;

--- a/shortfin/src/shortfin/local/systems/host.h
+++ b/shortfin/src/shortfin/local/systems/host.h
@@ -42,6 +42,11 @@ class SHORTFIN_API HostCPUSystemBuilder : public HostSystemBuilder {
   // must wholly replace this method, using protected piece-wise components.
   SystemPtr CreateSystem() override;
 
+  // Allocator specs to apply to hostcpu devices in this builder.
+  std::vector<std::string>& hostcpu_allocator_specs() {
+    return hostcpu_allocator_specs_;
+  }
+
  protected:
   // Initializes any host-cpu defaults that have not been configured yet.
   void InitializeHostCPUDefaults();
@@ -63,6 +68,8 @@ class SHORTFIN_API HostCPUSystemBuilder : public HostSystemBuilder {
     iree_host_size_t loader_count = 0;
     iree_hal_allocator_t* device_allocator = nullptr;
   } host_cpu_deps_;
+
+  std::vector<std::string> hostcpu_allocator_specs_;
 
  private:
   std::vector<iree_host_size_t> queue_node_ids_;

--- a/shortfin/tests/amdgpu_system_test.py
+++ b/shortfin/tests/amdgpu_system_test.py
@@ -44,7 +44,7 @@ def test_create_amd_gpu_logical_devices_per_physical_device():
     assert sc.logical_devices_per_physical_device == 1
 
     # Override.
-    sc = sf.amdgpu.SystemBuilder(amgdpu_logical_devices_per_physical_device=2)
+    sc = sf.amdgpu.SystemBuilder(amdgpu_logical_devices_per_physical_device=2)
     assert sc.logical_devices_per_physical_device == 2
     sc.visible_devices = sc.available_devices[0:1]
     with sc.create_system() as ls:

--- a/shortfin/tests/amdgpu_system_test.py
+++ b/shortfin/tests/amdgpu_system_test.py
@@ -29,6 +29,30 @@ def test_create_amd_gpu_tracing_level():
 
 
 @pytest.mark.system("amdgpu")
+def test_create_amd_gpu_allocator():
+    sc = sf.amdgpu.SystemBuilder(allocators="caching;debug")
+    assert sc.amdgpu_allocator_specs == ["caching", "debug"]
+    with sc.create_system() as ls:
+        # Nothing to verify
+        pass
+
+
+@pytest.mark.system("amdgpu")
+def test_create_amd_gpu_logical_devices_per_physical_device():
+    # Default.
+    sc = sf.amdgpu.SystemBuilder()
+    assert sc.logical_devices_per_physical_device == 1
+
+    # Override.
+    sc = sf.amdgpu.SystemBuilder(amgdpu_logical_devices_per_physical_device=2)
+    assert sc.logical_devices_per_physical_device == 2
+    sc.visible_devices = sc.available_devices[0:1]
+    with sc.create_system() as ls:
+        assert "amdgpu:0:0@0" in ls.device_names
+        assert "amdgpu:0:0@1" in ls.device_names
+
+
+@pytest.mark.system("amdgpu")
 def test_create_amd_gpu_system_defaults():
     sc = sf.amdgpu.SystemBuilder(amdgpu_cpu_devices_enabled=True)
     with sc.create_system() as ls:

--- a/shortfin/tests/conftest.py
+++ b/shortfin/tests/conftest.py
@@ -53,7 +53,11 @@ def pytest_runtest_setup(item):
 # Keys that will be cleaned project wide prior to and after each test run.
 # Test code can freely modify these.
 CLEAN_ENV_KEYS = [
+    "SHORTFIN_ALLOCATORS",
+    "SHORTFIN_AMDGPU_ALLOCATORS",
+    "SHORTFIN_AMDGPU_LOGICAL_DEVICES_PER_PHYSICAL_DEVICE",
     "SHORTFIN_AMDGPU_TRACING_LEVEL",
+    "SHORTFIN_HOSTCPU_ALLOCATORS",
     "SHORTFIN_HOSTCPU_TOPOLOGY_NODES",
     "SHORTFIN_HOSTCPU_TOPOLOGY_MAX_GROUP_COUNT",
     "SHORTFIN_SYSTEM_TYPE",

--- a/shortfin/tests/host_cpu_system_test.py
+++ b/shortfin/tests/host_cpu_system_test.py
@@ -58,6 +58,7 @@ def test_create_host_cpu_system_env_vars():
 
 
 def test_create_host_cpu_system_allocators():
+    pytest.skip("Setting allocators triggers LSAN leak. See #443")
     sc = sf.host.CPUSystemBuilder(hostcpu_allocators="caching;debug")
     assert sc.hostcpu_allocator_specs == ["caching", "debug"]
     with sc.create_system() as ls:

--- a/shortfin/tests/host_cpu_system_test.py
+++ b/shortfin/tests/host_cpu_system_test.py
@@ -57,6 +57,13 @@ def test_create_host_cpu_system_env_vars():
         assert len(ls.devices) == 2
 
 
+def test_create_host_cpu_system_allocators():
+    sc = sf.host.CPUSystemBuilder(hostcpu_allocators="caching;debug")
+    assert sc.hostcpu_allocator_specs == ["caching", "debug"]
+    with sc.create_system() as ls:
+        pass
+
+
 def test_create_host_cpu_system_unsupported_option():
     sc = sf.host.CPUSystemBuilder(unsupported="foobar")
     with pytest.raises(


### PR DESCRIPTION
* `allocators=`, `amdgpu_allocators=` and `hostcpu_allocators=` keywords control application of allocator decorators. Adding specifically to enable `caching`.
* `amdgpu_logical_devices_per_physical_device=n` will create `n` logical HAL devices per physical/visible AMDGPU device. This is used for some forms of multi-device distribution.

Filed #443 with a disabled test which seems to tickle an IREE memory leak in `iree_hal_configure_allocator_from_specs`.