### PR TITLE
Decrement sharktank and shortfin versions to 2.9.0.

### DIFF
--- a/sharktank/version_info.json
+++ b/sharktank/version_info.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "3.0.0.dev"
+  "package-version": "2.9.0.dev"
 }

--- a/shortfin/version_info.json
+++ b/shortfin/version_info.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "3.0.0.dev"
+  "package-version": "2.9.0.dev"
 }


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-Platform/issues/400.

Switching the versions to be earlier than the planned 3.0.0 will let us publish a 2.9.0 test release to PyPI and then increment the major version once we are comfortable with the new release process. I plan on deleting the existing 3.0.0 binaries that have been pushed to the "dev-wheels" release.

(Yes, pre-releases are a thing: https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases, but we want to trial the full release process)