### PR TITLE
Rework kv cache to avoid needless reshaping

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -214,6 +214,8 @@ def main():
 
                 cache_tensors = repack_cache(cs, cache_shard_dim)
 
+            cache_tensors = [model.cache.unflatten_page_table(cache_tensors)]
+
             logits = model.prefill(
                 tokens,
                 attention_mask=attention_mask,
@@ -299,6 +301,8 @@ def main():
                 seq_block_ids = ops.replicate(seq_block_ids, count=shard_count)
 
                 cache_state = repack_cache(cache_state, cache_shard_dim)
+
+            cache_state = [model.cache.unflatten_page_table(cache_state)]
 
             logits = model.decode(
                 tokens,

--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -284,6 +284,10 @@ class PagedKVCache(BaseKVCache):
         """Unflattens the 2D page table to a 6D tensor."""
         assert len(state) == 1, f"Expected 1-element state. Got: {len(state)}"
         page_slab = state[0]
+
+        if len(page_slab.shape) == 6:
+            return page_slab
+
         if self.shard_count == 1:
             assert not isinstance(page_slab, SplitPrimitiveTensor)
             return page_slab.unflatten(1, self.sub_page_dims)

--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -141,7 +141,7 @@ class DirectKVCache(BaseKVCache):
         self,
         state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         *,
-        read_into_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+        dest_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         transformer_block_index: int,
         seq_len: int,
         page_ids: Optional[Union[torch.Tensor, ReplicatedTensor]] = None,
@@ -150,7 +150,7 @@ class DirectKVCache(BaseKVCache):
 
         Args:
         state: State struct as returned from allocate().
-        read_into_partitions: List of cache partitions to read into in-place.
+        dest_partitions: List of cache partitions to read into in-place.
         transformer_block_index: The index of the transformer block accessing
             the cache.
         page_ids: Tensor of [bs, max_seqlen // block_pos_stride] of page ids
@@ -161,7 +161,7 @@ class DirectKVCache(BaseKVCache):
         materializing linearly may not be terribly efficient unless if the
         compiler can fuse the gather.
         """
-        read_count = len(read_into_partitions)
+        read_count = len(dest_partitions)
         reads = []
         for i in range(read_count):
             reads.append(
@@ -352,7 +352,7 @@ class PagedKVCache(BaseKVCache):
         self,
         state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         *,
-        read_into_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+        dest_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         transformer_block_index: int,
         seq_len: int,
         page_ids: Union[torch.Tensor, ReplicatedTensor],
@@ -361,7 +361,7 @@ class PagedKVCache(BaseKVCache):
 
         Args:
         state: State struct as returned from allocate().
-        read_into_partitions: List of cache partitions to read into in-place.
+        dest_partitions: List of cache partitions to read into in-place.
         transformer_block_index: The index of the transformer block accessing
             the cache.
         page_ids: Tensor of [bs, max_seqlen // block_pos_stride] of page ids
@@ -374,36 +374,9 @@ class PagedKVCache(BaseKVCache):
         """
         page_table = self.unflatten_page_table(state)  # 6D
 
-        bs, block_seq_len, *_ = page_ids.shape
-        # Blocks dim 1,2 according to the configured block stride.
-        blocked_shape = [
-            bs,
-            block_seq_len,
-            self.block_seq_stride,
-            self.attn_head_count // self.shard_count,
-            self.attn_head_dim,
-        ]
-
-        # Reshape the page cache into sub-blocks so that we can index at the
-        # granularity of the transformer_block and cache partition.
-        # This requires us to recompute indices to the sub-block reference
-        # frame.
-        # The subblock slab is organized as:
-        #   [page, attn_layer, cache_partition]
-        # Where the cache line can be 0 (k) or 1 (v).
-        subblock_table = page_table.flatten(start_dim=0, end_dim=2)
-        page_stride = self.transformer_block_count * self.cache_partition_count
-        transformer_block_stride = self.cache_partition_count
-        base_subblock_ids = page_ids * page_stride + (
-            transformer_block_index * transformer_block_stride
-        )
-
-        def read_cache_partition(
-            index: int, into_partition: Union[torch.Tensor, SplitPrimitiveTensor]
+        def read_cache_partitions(
+            into_partitions: List[Union[torch.Tensor, SplitPrimitiveTensor]]
         ):
-            subblock_ids = (
-                (base_subblock_ids + index) if index > 0 else base_subblock_ids
-            )
             # TODO: Potentially clamp all page 0 indices to the mask value.
             # Or even better, require that the ids are replicated such that access is
             # legal.
@@ -412,18 +385,16 @@ class PagedKVCache(BaseKVCache):
             # copy of the sub-blocks by collapsing the first two dims so we have
             # a linear list.
             # TODO: Can be rewritten into inplace with out= on index_select.
-            selected = (
-                ops.index_select(subblock_table, 0, subblock_ids.flatten(0, 1))
-                .unflatten(0, blocked_shape[0:2])
-                .flatten(1, 2)
-            )
-            # trace_tensor("kv.selected", selected)
-            into_partition[...] = selected
 
-        for index, read_into_partition in enumerate(read_into_partitions):
-            read_cache_partition(index, read_into_partition)
+            for i, into_partition in enumerate(into_partitions):
+                selected = page_table[
+                    page_ids.flatten(0, 1), transformer_block_index, i
+                ]
+                selected = selected.unflatten(0, page_ids.shape).flatten(1, 2)
+                into_partition[...] = selected
 
-        return tuple([p[:, :seq_len, :] for p in read_into_partitions])
+        read_cache_partitions(dest_partitions)
+        return tuple([p[:, :seq_len, :] for p in dest_partitions])
 
     def write_timestep(
         self,
@@ -488,46 +459,25 @@ class PagedKVCache(BaseKVCache):
         in-place scatter cannot be fused.
         """
         page_table = self.unflatten_page_table(state)  # 6D
-
-        bs, block_seq_len, *_ = page_ids.shape
-        # Blocks dim 1,2 according to the configured block stride.
-        blocked_shape = [
-            bs,
-            block_seq_len,
-            self.block_seq_stride,
-            self.attn_head_count,
-            self.attn_head_dim,
-        ]
-
-        # Reshape the page cache into sub-blocks so that we can index at the
-        # granularity of the transformer_block and cache partition.
-        # This requires us to recompute indices to the sub-block reference
-        # frame.
-        # The subblock slab is organized as:
-        #   [page, attn_layer, cache_partition]
-        # Where the cache line can be 0 (k) or 1 (v).
-        subblock_table = page_table.flatten(start_dim=0, end_dim=2)
-        page_stride = self.transformer_block_count * self.cache_partition_count
-        transformer_block_stride = self.cache_partition_count
-        base_subblock_ids = page_ids * page_stride + (
-            transformer_block_index * transformer_block_stride
-        )
+        _, block_seq_len, *_ = page_ids.shape
 
         part_block_views = []
-        subblock_ids_kv = []
-        for index, partition in enumerate(cache_partitions):
+        for partition in cache_partitions:
             part_block_view = partition.unflatten(
                 1, (block_seq_len, self.block_seq_stride)
             )
-            part_block_view = part_block_view.flatten(0, 1)
+            part_block_view = part_block_view.unsqueeze(2)
             part_block_views.append(part_block_view)
 
-            subblock_ids = (
-                (base_subblock_ids + index) if index > 0 else base_subblock_ids
-            ).flatten(0, 1)
-            subblock_ids_kv.append(subblock_ids)
+        part_block_view = ops.cat(part_block_views, dim=2)
 
-        subblock_ids = ops.cat(subblock_ids_kv)
-        part_block_view = ops.cat(part_block_views, dim=0)
+        page_ids = page_ids.flatten(0, 1)
+        part_block_view = part_block_view.flatten(0, 1)
 
-        subblock_table.index_copy_(0, subblock_ids, part_block_view)
+        page_table.index_put_(
+            (
+                page_ids,
+                torch.full(page_ids.shape, transformer_block_index, dtype=torch.int64),
+            ),
+            part_block_view,
+        )

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -241,7 +241,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         # Restore from the cache.
         xk, xv = cache.read(
             cache_state,
-            read_into_partitions=[
+            dest_partitions=[
                 xk_temp[:, 0:kv_seq_len, ...],
                 xv_temp[:, 0:kv_seq_len, ...],
             ],

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -56,7 +56,7 @@ def test_direct():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
     )
@@ -79,7 +79,7 @@ def test_direct():
         ]
         read_ones = cache.read(
             allocation,
-            read_into_partitions=read_ones,
+            dest_partitions=read_ones,
             transformer_block_index=i,
             seq_len=write_seq_length,
         )
@@ -113,7 +113,7 @@ def test_direct():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
     )
@@ -184,7 +184,7 @@ def test_sharded_direct():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
     )
@@ -225,7 +225,7 @@ def test_sharded_direct():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
     )
@@ -288,7 +288,7 @@ def test_paged():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -312,7 +312,7 @@ def test_paged():
         ]
         read_ones = cache.read(
             allocation,
-            read_into_partitions=read_ones,
+            dest_partitions=read_ones,
             transformer_block_index=i,
             seq_len=write_seq_length,
             page_ids=write_page_ids,
@@ -348,7 +348,7 @@ def test_paged():
     ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,
@@ -436,7 +436,7 @@ def test_sharded_paged():
 
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
+        dest_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -489,7 +489,7 @@ def test_sharded_paged():
 
     read_back = cache.read(
         allocation,
-        read_into_partitions=[empty_k, empty_v],
+        dest_partitions=[empty_k, empty_v],
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -104,7 +104,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             sharded_cache_state,
         ) = self.make_unsharded_and_sharded_equal_cache_states()
 
-        read_into_partitions_snapshot = [
+        dest_partitions_snapshot = [
             torch.rand(
                 self.batch_size,
                 self.block_seq_len * self.block_seq_stride,
@@ -113,35 +113,33 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             )
             for _ in range(self.cache_partition_count)
         ]
-        read_into_partitions = deepcopy(read_into_partitions_snapshot)
+        dest_partitions = deepcopy(dest_partitions_snapshot)
         transformer_block_index = 1
         page_ids = torch.randint(
             low=0, high=self.page_count, size=[self.batch_size, self.block_seq_len]
         ).reshape([self.batch_size, self.block_seq_len])
         self.cache.read(
             state=cache_state,
-            read_into_partitions=read_into_partitions,
+            dest_partitions=dest_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
-        sharded_read_into_partitions = deepcopy(
+        sharded_dest_partitions = deepcopy(
             [
                 ops.reshard_split(t, dim=2, count=self.shard_count)
-                for t in read_into_partitions_snapshot
+                for t in dest_partitions_snapshot
             ]
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
         self.sharded_cache.read(
             state=sharded_cache_state,
-            read_into_partitions=sharded_read_into_partitions,
+            dest_partitions=sharded_dest_partitions,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
-        for unsharded, sharded in zip(
-            read_into_partitions, sharded_read_into_partitions
-        ):
+        for unsharded, sharded in zip(dest_partitions, sharded_dest_partitions):
             assert ops.equal(unsharded, ops.unshard(sharded))
 
     def testWriteTimestep(self):


### PR DESCRIPTION
We should avoid reshaping the kv cache as much as possible. This change reduces the shape manipulations on the cache. KV cache test changes are only to update for arg rename, all observable behaviour should be the same.