### PR TITLE
[shortfin] Add missing build time dependency

### DIFF
--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "ninja",
+    'typing-extensions ; python_version == "3.10" ',
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Adds `typing-extensions` as a build time dependency as it required by nanobind, see https://github.com/nod-ai/SHARK-Platform/actions/runs/11777270868/job/32801349583#step:5:744