### PR TITLE
Add script to drop `rcYYYYMMDD` suffix from packages for PyPI deploy.

### DIFF
--- a/build_tools/promote_whl_from_rc_to_final.py
+++ b/build_tools/promote_whl_from_rc_to_final.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This scripts takes a file like
+# 'iree_base_runtime-2.9.0rc20241107-cp311-cp311-manylinux_2_28_x86_64.whl'
+# with embedded version '2.9.0rc20241107' as input and then drops the
+# 'rcYYYYMMDD' suffix from both the embedded version and file name.
+#
+# Typical usage:
+#   pip install -r requirements-pypi-deploy.txt
+#   ./promote_whl_from_rc_to_final.py /path/to/file.whl --delete-old-wheel
+
+import argparse
+from change_wheel_version import change_wheel_version
+from packaging.version import Version
+from pathlib import Path
+from pkginfo import Wheel
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "input_file",
+        help="Path to the input .whl file to promote",
+        type=Path,
+    )
+    parser.add_argument(
+        "--delete-old-wheel",
+        help="Deletes the original wheel after successfully promoting it",
+        action="store_true",
+        default=False,
+    )
+    return parser.parse_args()
+
+
+def main(args):
+    original_wheel_path = args.input_file
+    print(f"Promoting whl from rc to final: '{original_wheel_path}'")
+
+    original_wheel = Wheel(original_wheel_path)
+    original_version = Version(original_wheel.version)
+    base_version = original_version.base_version
+    print(
+        f"  Original wheel version is '{original_version}' with base '{base_version}'"
+    )
+
+    if str(base_version) == str(original_version):
+        print("  Version is already a release version, skipping")
+        return
+
+    print(f"  Changing to base version: '{base_version}'")
+    new_wheel_path = change_wheel_version(original_wheel_path, str(base_version), None)
+    print(f"  New wheel path is '{new_wheel_path}'")
+
+    new_wheel = Wheel(new_wheel_path)
+    new_version = Version(new_wheel.version)
+    print(f"  New wheel version is '{new_version}'")
+
+    if args.delete_old_wheel:
+        print("  Deleting original wheel")
+        original_wheel_path.unlink()
+
+
+if __name__ == "__main__":
+    main(parse_arguments())

--- a/build_tools/promote_whl_from_rc_to_final.py
+++ b/build_tools/promote_whl_from_rc_to_final.py
@@ -6,9 +6,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# This scripts takes a file like
-# 'iree_base_runtime-2.9.0rc20241107-cp311-cp311-manylinux_2_28_x86_64.whl'
-# with embedded version '2.9.0rc20241107' as input and then drops the
+# This scripts takes a file like 'sharktank-2.9.0rc20241110-py3-none-any.whl'
+# with embedded version '2.9.0rc20241110' as input and then drops the
 # 'rcYYYYMMDD' suffix from both the embedded version and file name.
 #
 # Typical usage:

--- a/build_tools/promote_whl_from_rc_to_final.py
+++ b/build_tools/promote_whl_from_rc_to_final.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 The IREE Authors
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/requirements-pypi-deploy.txt
+++ b/build_tools/requirements-pypi-deploy.txt
@@ -1,0 +1,4 @@
+change_wheel_version
+packaging
+pkginfo
+twine


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-Platform/issues/400

This lets us take a release from https://github.com/nod-ai/SHARK-Platform/releases/tag/dev-wheels and "promote it" for publishing to https://pypi.org/ by turning the version from `X.Y.ZrcYYYYMMDD` to simply `X.Y.Z`. The script is forked from the one in IREE I added last week: https://github.com/iree-org/iree/pull/19067.

More steps like https://iree.dev/developers/general/release-management/#promoting-a-candidate-to-stable and scripting like https://github.com/iree-org/iree/blob/main/build_tools/python_deploy/pypi_deploy.sh will follow.