### PR TITLE
Add metadata to shortfin Python package

### DIFF
--- a/shortfin/README.md
+++ b/shortfin/README.md
@@ -1,4 +1,4 @@
-# shortfin - SHARK C++ inference library
+# shortfin - SHARK inference library and serving engine
 
 ## Simple User Installation
 

--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -8,6 +8,32 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "shortfin"
+authors = [
+  {name = "SHARK Authors"},
+]
+description = "SHARK inference library and serving engine"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+requires-python = ">= 3.10"
+
+# Version is set via the `setup.py`.
+dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/nod-ai/SHARK-Platform"
+Documentation = "https://shortfin.readthedocs.io/en/latest/"
+
 [tool.pytest.ini_options]
 addopts = [
     "-ra",

--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -359,10 +359,7 @@ packages = find_namespace_packages(
 print(f"Found shortfin packages: {packages}")
 
 setup(
-    name="shortfin",
     version=f"{PACKAGE_VERSION}",
-    description="Shortfin native library implementation",
-    author="SHARK Authors",
     packages=packages,
     zip_safe=False,
     package_dir=combine_dicts(


### PR DESCRIPTION
Similar to #489, this adds mertadata to the shortfin Python package but does so by extending the `pyproject.toml` file instead of adding metadata to the `setup.py` file.