### PR TITLE
Adapt to package rename

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -63,7 +63,7 @@ jobs:
 
           # Update to the latest iree packages.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-compiler iree-runtime --src deps \
+            iree-base-compiler iree-base-runtime --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
 
       - name: Run sharktank tests


### PR DESCRIPTION
The packages were recently renamed from `iree-compiler` and `iree-runtime` to `iree-base-compiler` and `iree-base-compiler`, respectively.