### PR TITLE
Fix workflows installing nightly IREE packages to use `--pre`.

### DIFF
--- a/.github/workflows/ci-shark-platform.yml
+++ b/.github/workflows/ci-shark-platform.yml
@@ -67,7 +67,7 @@ jobs:
           # Try with the latest IREE nightly releases, not what iree-turbine pins.
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
             iree-base-compiler \
             iree-base-runtime \
             "numpy<2.0"

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -62,7 +62,7 @@ jobs:
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
           # Update to the latest iree packages.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
             iree-base-compiler iree-base-runtime --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
 

--- a/.github/workflows/ci-tuner.yml
+++ b/.github/workflows/ci-tuner.yml
@@ -49,7 +49,7 @@ jobs:
           pip install -r tuner/requirements-tuner.txt
           python -m pip install \
             --find-links https://iree.dev/pip-release-links.html \
-            --upgrade \
+            --upgrade --pre \
             iree-base-compiler iree-base-runtime
 
       - name: Run tuner tests

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -69,7 +69,7 @@ jobs:
           # Try with the latest IREE nightly releases, not what iree-turbine pins.
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
             iree-base-compiler \
             iree-base-runtime \
             "numpy<2.0"

--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -106,14 +106,14 @@ To install the `iree-base-compiler` and `iree-base-runtime` packages from
 nightly releases:
 
 ```bash
-python -m pip install -f https://iree.dev/pip-release-links.html --upgrade \
+python -m pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
   iree-base-compiler iree-base-runtime
 ```
 
 To install all three packages together:
 
 ```bash
-python -m pip install -f https://iree.dev/pip-release-links.html --upgrade \
+python -m pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
   iree-base-compiler iree-base-runtime --src deps \
   -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
 ```


### PR DESCRIPTION
Pip will only install "pre-release" versions if `--pre` is set or the version is set explicitly: https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions. The `rc` part of our `rcYYYYMMDD` suffix used in the nightly IREE packages is considered a "Pre-release segment" in the version string: https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers.

This should change workflow jobs like https://github.com/nod-ai/SHARK-Platform/actions/runs/11827078971/job/32954462017#step:5:163 that have been downloading `iree-base-compiler-2.9.0 iree-base-runtime-2.9.0` to downloading the latest nightly versions instead, as they intend: https://github.com/nod-ai/SHARK-Platform/blob/51cf2f45139f67e15434990173b49375998db9f3/.github/workflows/ci-sharktank.yml#L64-L67