### PR TITLE
Revert "Rework kv cache to avoid needless reshaping (#450)"

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -214,8 +214,6 @@ def main():
 
                 cache_tensors = repack_cache(cs, cache_shard_dim)
 
-            cache_tensors = [model.cache.unflatten_page_table(cache_tensors)]
-
             logits = model.prefill(
                 tokens,
                 attention_mask=attention_mask,
@@ -301,8 +299,6 @@ def main():
                 seq_block_ids = ops.replicate(seq_block_ids, count=shard_count)
 
                 cache_state = repack_cache(cache_state, cache_shard_dim)
-
-            cache_state = [model.cache.unflatten_page_table(cache_state)]
 
             logits = model.decode(
                 tokens,

--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -141,7 +141,7 @@ class DirectKVCache(BaseKVCache):
         self,
         state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         *,
-        dest_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+        read_into_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         transformer_block_index: int,
         seq_len: int,
         page_ids: Optional[Union[torch.Tensor, ReplicatedTensor]] = None,
@@ -150,7 +150,7 @@ class DirectKVCache(BaseKVCache):
 
         Args:
         state: State struct as returned from allocate().
-        dest_partitions: List of cache partitions to read into in-place.
+        read_into_partitions: List of cache partitions to read into in-place.
         transformer_block_index: The index of the transformer block accessing
             the cache.
         page_ids: Tensor of [bs, max_seqlen // block_pos_stride] of page ids
@@ -161,7 +161,7 @@ class DirectKVCache(BaseKVCache):
         materializing linearly may not be terribly efficient unless if the
         compiler can fuse the gather.
         """
-        read_count = len(dest_partitions)
+        read_count = len(read_into_partitions)
         reads = []
         for i in range(read_count):
             reads.append(
@@ -284,10 +284,6 @@ class PagedKVCache(BaseKVCache):
         """Unflattens the 2D page table to a 6D tensor."""
         assert len(state) == 1, f"Expected 1-element state. Got: {len(state)}"
         page_slab = state[0]
-
-        if len(page_slab.shape) == 6:
-            return page_slab
-
         if self.shard_count == 1:
             assert not isinstance(page_slab, SplitPrimitiveTensor)
             return page_slab.unflatten(1, self.sub_page_dims)
@@ -356,7 +352,7 @@ class PagedKVCache(BaseKVCache):
         self,
         state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         *,
-        dest_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
+        read_into_partitions: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         transformer_block_index: int,
         seq_len: int,
         page_ids: Union[torch.Tensor, ReplicatedTensor],
@@ -365,7 +361,7 @@ class PagedKVCache(BaseKVCache):
 
         Args:
         state: State struct as returned from allocate().
-        dest_partitions: List of cache partitions to read into in-place.
+        read_into_partitions: List of cache partitions to read into in-place.
         transformer_block_index: The index of the transformer block accessing
             the cache.
         page_ids: Tensor of [bs, max_seqlen // block_pos_stride] of page ids
@@ -378,9 +374,36 @@ class PagedKVCache(BaseKVCache):
         """
         page_table = self.unflatten_page_table(state)  # 6D
 
-        def read_cache_partitions(
-            into_partitions: List[Union[torch.Tensor, SplitPrimitiveTensor]]
+        bs, block_seq_len, *_ = page_ids.shape
+        # Blocks dim 1,2 according to the configured block stride.
+        blocked_shape = [
+            bs,
+            block_seq_len,
+            self.block_seq_stride,
+            self.attn_head_count // self.shard_count,
+            self.attn_head_dim,
+        ]
+
+        # Reshape the page cache into sub-blocks so that we can index at the
+        # granularity of the transformer_block and cache partition.
+        # This requires us to recompute indices to the sub-block reference
+        # frame.
+        # The subblock slab is organized as:
+        #   [page, attn_layer, cache_partition]
+        # Where the cache line can be 0 (k) or 1 (v).
+        subblock_table = page_table.flatten(start_dim=0, end_dim=2)
+        page_stride = self.transformer_block_count * self.cache_partition_count
+        transformer_block_stride = self.cache_partition_count
+        base_subblock_ids = page_ids * page_stride + (
+            transformer_block_index * transformer_block_stride
+        )
+
+        def read_cache_partition(
+            index: int, into_partition: Union[torch.Tensor, SplitPrimitiveTensor]
         ):
+            subblock_ids = (
+                (base_subblock_ids + index) if index > 0 else base_subblock_ids
+            )
             # TODO: Potentially clamp all page 0 indices to the mask value.
             # Or even better, require that the ids are replicated such that access is
             # legal.
@@ -389,16 +412,18 @@ class PagedKVCache(BaseKVCache):
             # copy of the sub-blocks by collapsing the first two dims so we have
             # a linear list.
             # TODO: Can be rewritten into inplace with out= on index_select.
+            selected = (
+                ops.index_select(subblock_table, 0, subblock_ids.flatten(0, 1))
+                .unflatten(0, blocked_shape[0:2])
+                .flatten(1, 2)
+            )
+            # trace_tensor("kv.selected", selected)
+            into_partition[...] = selected
 
-            for i, into_partition in enumerate(into_partitions):
-                selected = page_table[
-                    page_ids.flatten(0, 1), transformer_block_index, i
-                ]
-                selected = selected.unflatten(0, page_ids.shape).flatten(1, 2)
-                into_partition[...] = selected
+        for index, read_into_partition in enumerate(read_into_partitions):
+            read_cache_partition(index, read_into_partition)
 
-        read_cache_partitions(dest_partitions)
-        return tuple([p[:, :seq_len, :] for p in dest_partitions])
+        return tuple([p[:, :seq_len, :] for p in read_into_partitions])
 
     def write_timestep(
         self,
@@ -463,25 +488,46 @@ class PagedKVCache(BaseKVCache):
         in-place scatter cannot be fused.
         """
         page_table = self.unflatten_page_table(state)  # 6D
-        _, block_seq_len, *_ = page_ids.shape
+
+        bs, block_seq_len, *_ = page_ids.shape
+        # Blocks dim 1,2 according to the configured block stride.
+        blocked_shape = [
+            bs,
+            block_seq_len,
+            self.block_seq_stride,
+            self.attn_head_count,
+            self.attn_head_dim,
+        ]
+
+        # Reshape the page cache into sub-blocks so that we can index at the
+        # granularity of the transformer_block and cache partition.
+        # This requires us to recompute indices to the sub-block reference
+        # frame.
+        # The subblock slab is organized as:
+        #   [page, attn_layer, cache_partition]
+        # Where the cache line can be 0 (k) or 1 (v).
+        subblock_table = page_table.flatten(start_dim=0, end_dim=2)
+        page_stride = self.transformer_block_count * self.cache_partition_count
+        transformer_block_stride = self.cache_partition_count
+        base_subblock_ids = page_ids * page_stride + (
+            transformer_block_index * transformer_block_stride
+        )
 
         part_block_views = []
-        for partition in cache_partitions:
+        subblock_ids_kv = []
+        for index, partition in enumerate(cache_partitions):
             part_block_view = partition.unflatten(
                 1, (block_seq_len, self.block_seq_stride)
             )
-            part_block_view = part_block_view.unsqueeze(2)
+            part_block_view = part_block_view.flatten(0, 1)
             part_block_views.append(part_block_view)
 
-        part_block_view = ops.cat(part_block_views, dim=2)
+            subblock_ids = (
+                (base_subblock_ids + index) if index > 0 else base_subblock_ids
+            ).flatten(0, 1)
+            subblock_ids_kv.append(subblock_ids)
 
-        page_ids = page_ids.flatten(0, 1)
-        part_block_view = part_block_view.flatten(0, 1)
+        subblock_ids = ops.cat(subblock_ids_kv)
+        part_block_view = ops.cat(part_block_views, dim=0)
 
-        page_table.index_put_(
-            (
-                page_ids,
-                torch.full(page_ids.shape, transformer_block_index, dtype=torch.int64),
-            ),
-            part_block_view,
-        )
+        subblock_table.index_copy_(0, subblock_ids, part_block_view)

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -241,7 +241,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         # Restore from the cache.
         xk, xv = cache.read(
             cache_state,
-            dest_partitions=[
+            read_into_partitions=[
                 xk_temp[:, 0:kv_seq_len, ...],
                 xv_temp[:, 0:kv_seq_len, ...],
             ],

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -485,7 +485,11 @@ class PrimitiveTensor(InferenceTensor):
         return self.as_torch().dtype
 
     def __setitem__(self, key, value: "AnyTensor"):
-        self.as_torch()[key] = unbox_tensor(value)
+        if not isinstance(key, list) and not isinstance(key, tuple):
+            key = (key,)
+
+        key = [unbox_tensor(k) if isinstance(k, PrimitiveTensor) else k for k in key]
+        self.as_torch()[*key] = unbox_tensor(value)
 
 
 @register_inference_tensor
@@ -540,9 +544,15 @@ class DefaultPrimitiveTensor(PrimitiveTensor):
         return DefaultPrimitiveTensor(name=self.name, data=new_globals[self.name])
 
     def __getitem__(self, key):
-        if isinstance(key, PrimitiveTensor):
-            key = unbox_tensor(key)
-        return self._data[key]
+        keys = [key]
+        if isinstance(key, tuple) or isinstance(key, list):
+            keys = key
+
+        keys = [
+            unbox_tensor(key) if isinstance(key, PrimitiveTensor) else key
+            for key in keys
+        ]
+        return self._data[*keys]
 
     def __repr__(self):
         return f"PrimitiveTensor({self.name}, {self.shape}, {self._data.dtype})"
@@ -1026,7 +1036,9 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         if len(key) <= self.shard_count:
             return key
         new_key = list(key)
-        new_key[self.shard_dim] = slice(None)
+
+        if self.shard_dim < len(new_key):
+            new_key[self.shard_dim] = slice(None)
         return new_key
 
     def __getitem__(self, key):
@@ -1039,10 +1051,16 @@ class SplitPrimitiveTensor(ShardedTensorBase):
                 f"Slicing of the split dimension {self.shard_dim} is not supported."
             )
         new_key = self._get_shard_slice(key)
-        shards = [shard[new_key] for shard in self.shards]
+
+        shards = []
+        for i, shard in enumerate(self.shards):
+            shard_keys = [
+                k.shards[i] if isinstance(k, ReplicatedTensor) else k for k in new_key
+            ]
+            shards.append(shard[*shard_keys])
 
         shard_dim = self.shard_dim
-        for i in range(shard_dim):
+        for i in range(min(shard_dim, len(key))):
             if isinstance(key[i], Number) and key[i] >= 0:
                 # Rank reduction dimension before the split dim.
                 shard_dim -= 1
@@ -1059,8 +1077,11 @@ class SplitPrimitiveTensor(ShardedTensorBase):
             raise NotImplementedError(
                 f"Slicing of the split dimension {self.shard_dim} is not supported."
             )
-        for shard, value_shard in zip(self.shards, value.shards):
-            shard[key] = unbox_tensor(value_shard)
+        for i, (shard, value_shard) in enumerate(zip(self.shards, value.shards)):
+            shard_keys = [
+                k.shards[i] if isinstance(k, ReplicatedTensor) else k for k in key
+            ]
+            shard[*shard_keys] = unbox_tensor(value_shard)
 
 
 @register_inference_tensor
@@ -1169,13 +1190,19 @@ class ReplicatedTensor(ShardedTensor):
         return cls(name=name, ts=ts)
 
     def __getitem__(self, key):
-        if isinstance(key, ReplicatedTensor):
-            assert key.shard_count == self.shard_count
-            shards = [
-                shard[key_shard] for shard, key_shard in zip(self.shards, key.shards)
-            ]
-        else:
-            shards = [shard[key] for shard in self.shards]
+        keys = [key]
+        if isinstance(keys, tuple) or isinstance(keys, list):
+            keys = key
+
+        shards = []
+        for i, shard in enumerate(self.shards):
+            shard_keys = []
+            for k in keys:
+                if isinstance(k, ReplicatedTensor):
+                    shard_keys.append(k.shards[i])
+                else:
+                    shard_keys.append(k)
+            shards.append(shard[*shard_keys])
         return ReplicatedTensor(ts=shards)
 
     def __repr__(self):

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -56,7 +56,7 @@ def test_direct():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
     )
@@ -79,7 +79,7 @@ def test_direct():
         ]
         read_ones = cache.read(
             allocation,
-            dest_partitions=read_ones,
+            read_into_partitions=read_ones,
             transformer_block_index=i,
             seq_len=write_seq_length,
         )
@@ -113,7 +113,7 @@ def test_direct():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
     )
@@ -184,7 +184,7 @@ def test_sharded_direct():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
     )
@@ -225,7 +225,7 @@ def test_sharded_direct():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
     )
@@ -288,7 +288,7 @@ def test_paged():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -312,7 +312,7 @@ def test_paged():
         ]
         read_ones = cache.read(
             allocation,
-            dest_partitions=read_ones,
+            read_into_partitions=read_ones,
             transformer_block_index=i,
             seq_len=write_seq_length,
             page_ids=write_page_ids,
@@ -348,7 +348,7 @@ def test_paged():
     ]
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,
@@ -436,7 +436,7 @@ def test_sharded_paged():
 
     read_back = cache.read(
         allocation,
-        dest_partitions=read_empty,
+        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -489,7 +489,7 @@ def test_sharded_paged():
 
     read_back = cache.read(
         allocation,
-        dest_partitions=[empty_k, empty_v],
+        read_into_partitions=[empty_k, empty_v],
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,


### PR DESCRIPTION
This reverts commit b36ddf7842e7124926b5f99d89e504bcbef93753.

The beginning of the fix to the brand new November KV cache issue