### PR TITLE
Update package versions to 3.0.0.

### DIFF
--- a/sharktank/version.json
+++ b/sharktank/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.1.dev"
+  "package-version": "3.0.0.dev"
 }

--- a/shortfin/version.json
+++ b/shortfin/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.1.dev"
+  "package-version": "3.0.0.dev"
 }

--- a/tuner/version.json
+++ b/tuner/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.1.dev"
+  "package-version": "3.0.0.dev"
 }


### PR DESCRIPTION
We just published version 2.9.1 to PyPI, so update the version to 3.0.0 ahead of the next nightly build.

Note: updating the version and rebuilding a release is relatively cheap in this project, since the release build action only takes 5 minutes. We can reduce the version if we want, or update it after a nightly build. That is _not_ the case in https://github.com/iree-org/iree, where the release build takes over 4 hours.