### PR TITLE
Update pyproject to include missing SDXL app deps

### DIFF
--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -39,6 +39,9 @@ apps = [
   "transformers",
   "dataclasses-json",
   "pillow",
+  "fastapi",
+  "uvicorn",
+  "aiohttp",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Update pyproject to include missing SDXL app deps. These were discovered while testing shortfin apps flow by only pre-installing the shark meta pkg